### PR TITLE
refactor: organize some imports based on the order of importance

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,10 @@
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import fastifyMultipart from 'fastify-multipart'
 import fastifySwagger from 'fastify-swagger'
-import { errorSchema } from './schemas/error'
-import { authSchema } from './schemas/auth'
-
 import bucketRoutes from './routes/bucket/'
 import objectRoutes from './routes/object'
+import { authSchema } from './schemas/auth'
+import { errorSchema } from './schemas/error'
 import { getConfig } from './utils/config'
 
 interface buildOpts extends FastifyServerOptions {

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -1,9 +1,9 @@
 import { FastifyInstance } from 'fastify'
-import { verifyJWT } from '../../utils/'
-import { getObject, initClient } from '../../utils/s3'
-import { getConfig } from '../../utils/config'
-import { signedToken } from '../../types/types'
 import { FromSchema } from 'json-schema-to-ts'
+import { SignedToken } from '../../types/types'
+import { verifyJWT } from '../../utils/'
+import { getConfig } from '../../utils/config'
+import { getObject, initClient } from '../../utils/s3'
 
 const { region, projectRef, globalS3Bucket, globalS3Endpoint } = getConfig()
 const client = initClient(region, globalS3Endpoint)
@@ -45,7 +45,7 @@ export default async function routes(fastify: FastifyInstance) {
       const { token } = request.query
       try {
         const payload = await verifyJWT(token)
-        const { url } = payload as signedToken
+        const { url } = payload as SignedToken
         const s3Key = `${projectRef}/${url}`
         request.log.info(s3Key)
         const data = await getObject(client, globalS3Bucket, s3Key)

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,11 +7,10 @@ const loggerConfig = {
   prettyPrint: true,
   level: 'info',
 }
-let exposeDocs = true
+const exposeDocs = true
 if (process.env.NODE_ENV === 'production') {
   loggerConfig.prettyPrint = false
   loggerConfig.level = 'error'
-  exposeDocs = true
 }
 
 ;(async () => {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,12 +1,12 @@
 import { RequestGenericInterface } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
-import { objectSchema } from '../schemas/object'
 import { bucketSchema } from '../schemas/bucket'
+import { objectSchema } from '../schemas/object'
 
 export type Bucket = FromSchema<typeof bucketSchema>
 export type Obj = FromSchema<typeof objectSchema>
 
-export type signedToken = {
+export type SignedToken = {
   url: string
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 
-type storageConfigType = {
+type StorageConfigType = {
   anonKey: string
   serviceKey: string
   projectRef: string
@@ -12,19 +12,19 @@ type storageConfigType = {
   fileSizeLimit: number
 }
 
+function getOptionalConfigFromEnv(key: string): string | undefined {
+  return process.env[key]
+}
+
 function getConfigFromEnv(key: string): string {
-  const value = process.env[key]
+  const value = getOptionalConfigFromEnv(key)
   if (!value) {
     throw new Error(`${key} is undefined`)
   }
   return value
 }
 
-function getOptionalConfigFromEnv(key: string): string | undefined {
-  return process.env[key]
-}
-
-export function getConfig(): storageConfigType {
+export function getConfig(): StorageConfigType {
   dotenv.config()
 
   return {

--- a/src/utils/migrate-call.ts
+++ b/src/utils/migrate-call.ts
@@ -1,5 +1,5 @@
-import { runMigrations } from './migrate'
 import dotenv from 'dotenv'
+import { runMigrations } from './migrate'
 dotenv.config()
 ;(async () => {
   await runMigrations()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Some small improvements  🚀 

## What is the current behavior?

## What is the new behavior?

Both behaviours remain the same.

## Additional context

- refactor: change types to start as capital letters
- refactor: organize some imports based on the order of importance*
  -  *If you're using VSCode you can add this configuration by project:

```json
"[javascript, typescript, tsx]": {
  "source.organizeImports": true
}
```