### PR TITLE
refactor: create two generic methods and use them to avoid repetition

### DIFF
--- a/src/routes/bucket/getAllBuckets.ts
+++ b/src/routes/bucket/getAllBuckets.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify'
 import { getPostgrestClient, transformPostgrestError } from '../../utils'
 import { AuthenticatedRequest, Bucket } from '../../types/types'
 import { bucketSchema } from '../../schemas/bucket'
+import { createDefaultSchema } from '../../utils/generic-routes'
 
 const successResponseSchema = {
   type: 'array',
@@ -11,14 +12,14 @@ const successResponseSchema = {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Gets all buckets'
+  const schema = createDefaultSchema(successResponseSchema, {
+    summary,
+  })
+
   fastify.get<AuthenticatedRequest>(
     '/',
     {
-      schema: {
-        headers: { $ref: 'authSchema#' },
-        summary,
-        response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
-      },
+      schema,
     },
     async (request, response) => {
       // get list of all buckets

--- a/src/routes/bucket/getBucket.ts
+++ b/src/routes/bucket/getBucket.ts
@@ -3,6 +3,7 @@ import { getPostgrestClient, transformPostgrestError } from '../../utils'
 import { AuthenticatedRequest, Bucket } from '../../types/types'
 import { FromSchema } from 'json-schema-to-ts'
 import { bucketSchema } from '../../schemas/bucket'
+import { createDefaultSchema } from '../../utils/generic-routes'
 
 const getBucketParamsSchema = {
   type: 'object',
@@ -20,15 +21,14 @@ interface getBucketRequestInterface extends AuthenticatedRequest {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Get details of a bucket'
+  const schema = createDefaultSchema(successResponseSchema, {
+    params: getBucketParamsSchema,
+    summary,
+  })
   fastify.get<getBucketRequestInterface>(
     '/:bucketId',
     {
-      schema: {
-        params: getBucketParamsSchema,
-        headers: { $ref: 'authSchema#' },
-        summary,
-        response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
-      },
+      schema,
     },
     async (request, response) => {
       const authHeader = request.headers.authorization

--- a/src/routes/object/deleteObjects.ts
+++ b/src/routes/object/deleteObjects.ts
@@ -5,6 +5,7 @@ import { getConfig } from '../../utils/config'
 import { AuthenticatedRequest, Obj } from '../../types/types'
 import { FromSchema } from 'json-schema-to-ts'
 import { objectSchema } from '../../schemas/object'
+import { createDefaultSchema } from '../../utils/generic-routes'
 
 const { region, projectRef, globalS3Bucket, globalS3Endpoint } = getConfig()
 const client = initClient(region, globalS3Endpoint)
@@ -35,16 +36,17 @@ interface deleteObjectsInterface extends AuthenticatedRequest {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Delete multiple objects'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: deleteObjectsBodySchema,
+    params: deleteObjectsParamsSchema,
+    summary,
+  })
+
   fastify.delete<deleteObjectsInterface>(
     '/:bucketName',
     {
-      schema: {
-        body: deleteObjectsBodySchema,
-        params: deleteObjectsParamsSchema,
-        headers: { $ref: 'authSchema#' },
-        summary,
-        response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
-      },
+      schema,
     },
     async (request, response) => {
       // check if the user is able to insert that row

--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -4,6 +4,7 @@ import { getPostgrestClient, isValidKey, transformPostgrestError } from '../../u
 import { getObject, initClient } from '../../utils/s3'
 import { getConfig } from '../../utils/config'
 import { AuthenticatedRequest, Obj } from '../../types/types'
+import { createResponse } from '../../utils/generic-routes'
 
 const { region, projectRef, globalS3Bucket, globalS3Endpoint } = getConfig()
 const client = initClient(region, globalS3Endpoint)
@@ -43,11 +44,9 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
 
       if (!isValidKey(objectName) || !isValidKey(bucketName)) {
-        return response.status(400).send({
-          statusCode: '400',
-          error: 'Invalid key',
-          message: 'The key contains invalid characters',
-        })
+        return response
+          .status(400)
+          .send(createResponse('The key contains invalid characters', '400', 'Invalid key'))
       }
 
       const objectResponse = await postgrest

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -3,7 +3,6 @@ import { FromSchema } from 'json-schema-to-ts'
 import { SignedToken } from '../../types/types'
 import { verifyJWT } from '../../utils/'
 import { getConfig } from '../../utils/config'
-import { FromSchema } from 'json-schema-to-ts'
 import { createResponse } from '../../utils/generic-routes'
 import { getObject, initClient } from '../../utils/s3'
 

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -4,6 +4,7 @@ import { getObject, initClient } from '../../utils/s3'
 import { getConfig } from '../../utils/config'
 import { signedToken } from '../../types/types'
 import { FromSchema } from 'json-schema-to-ts'
+import { createResponse } from '../../utils/generic-routes'
 
 const { region, projectRef, globalS3Bucket, globalS3Endpoint } = getConfig()
 const client = initClient(region, globalS3Endpoint)
@@ -59,11 +60,7 @@ export default async function routes(fastify: FastifyInstance) {
           .send(data.Body)
       } catch (err) {
         request.log.error(err)
-        return response.status(400).send({
-          statusCode: '400',
-          error: err.name,
-          message: err.message,
-        })
+        return response.status(400).send(createResponse(err.message, '400', err.name))
       }
     }
   )

--- a/src/routes/object/getSignedURL.ts
+++ b/src/routes/object/getSignedURL.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify'
 import { getPostgrestClient, signJWT, transformPostgrestError } from '../../utils'
 import { AuthenticatedRequest, Obj } from '../../types/types'
 import { FromSchema } from 'json-schema-to-ts'
+import { createDefaultSchema } from '../../utils/generic-routes'
 
 const getSignedURLParamsSchema = {
   type: 'object',
@@ -33,16 +34,17 @@ interface getSignedURLRequestInterface extends AuthenticatedRequest {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Generate a presigned url to retrieve an object'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: getSignedURLBodySchema,
+    params: getSignedURLParamsSchema,
+    summary,
+  })
+
   fastify.post<getSignedURLRequestInterface>(
     '/sign/:bucketName/*',
     {
-      schema: {
-        body: getSignedURLBodySchema,
-        params: getSignedURLParamsSchema,
-        headers: { $ref: 'authSchema#' },
-        summary,
-        response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
-      },
+      schema,
     },
     async (request, response) => {
       const authHeader = request.headers.authorization

--- a/src/routes/object/listObjects.ts
+++ b/src/routes/object/listObjects.ts
@@ -3,6 +3,7 @@ import { getPostgrestClient, transformPostgrestError } from '../../utils'
 import { FromSchema } from 'json-schema-to-ts'
 import { AuthenticatedRequest } from '../../types/types'
 import { objectSchema } from '../../schemas/object'
+import { createDefaultSchema } from '../../utils/generic-routes'
 
 const searchRequestParamsSchema = {
   type: 'object',
@@ -39,16 +40,17 @@ interface searchRequestInterface extends AuthenticatedRequest {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Search for objects under a prefix'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: searchRequestBodySchema,
+    params: searchRequestParamsSchema,
+    summary,
+  })
+
   fastify.post<searchRequestInterface>(
     '/list/:bucketName',
     {
-      schema: {
-        body: searchRequestBodySchema,
-        params: searchRequestParamsSchema,
-        headers: { $ref: 'authSchema#' },
-        summary,
-        response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
-      },
+      schema,
     },
     async (request, response) => {
       const authHeader = request.headers.authorization

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -185,7 +185,7 @@ describe('testing DELETE bucket', () => {
     })
     expect(response.statusCode).toBe(200)
     const responseJSON = JSON.parse(response.body)
-    expect(responseJSON.message).toBe('Deleted')
+    expect(responseJSON.message).toBe('Successfully deleted')
   })
 
   test('checking RLS: anon user is not able to delete a bucket', async () => {
@@ -246,7 +246,7 @@ describe('testing EMPTY bucket', () => {
     })
     expect(response.statusCode).toBe(200)
     const responseJSON = JSON.parse(response.body)
-    expect(responseJSON.message).toBe('Emptied')
+    expect(responseJSON.message).toBe('Successfully deflated')
   })
 
   test('user is able to delete a bucket', async () => {

--- a/src/test/generic-routes.test.ts
+++ b/src/test/generic-routes.test.ts
@@ -1,0 +1,75 @@
+'use strict'
+
+import { createDefaultSchema, createResponse } from '../utils/generic-routes'
+
+describe('testing Generic Routes Utils', () => {
+  describe('creating generic responses [createResponse]', () => {
+    test('create generic response with all values', () => {
+      const response = {
+        message: 'Invalid schema',
+        statusCode: '400',
+        error: 'Invalid schema error message',
+      }
+
+      expect(createResponse('Invalid schema', '400', 'Invalid schema error message')).toEqual(
+        response
+      )
+    })
+
+    test('create generic response without status', () => {
+      const response = {
+        message: 'Invalid schema',
+        error: 'Invalid schema error message',
+      }
+
+      expect(createResponse('Invalid schema', undefined, 'Invalid schema error message')).toEqual(
+        response
+      )
+    })
+
+    test('create generic response without error', () => {
+      const response = {
+        message: 'Invalid schema',
+        statusCode: '400',
+      }
+
+      expect(createResponse('Invalid schema', '400')).toEqual(response)
+    })
+
+    test('create generic response only message', () => {
+      const response = {
+        message: 'Invalid schema',
+      }
+
+      expect(createResponse('Invalid schema')).toEqual(response)
+    })
+  })
+
+  describe('creating generic schema [createDefaultSchema]', () => {
+    test('create generic schema without additional properties', () => {
+      const successResponseSchema = { generic: 'example' }
+      const response = {
+        schema: {
+          headers: { $ref: 'authSchema#' },
+          response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
+        },
+      }
+
+      expect(createDefaultSchema(successResponseSchema, {})).toEqual(response)
+    })
+
+    test('create generic schema with additional properties', () => {
+      const successResponseSchema = { generic: 'example' }
+      const additionalProperties = { generic: 'example' }
+      const response = {
+        schema: {
+          headers: { $ref: 'authSchema#' },
+          response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
+          ...additionalProperties,
+        },
+      }
+
+      expect(createDefaultSchema(successResponseSchema, additionalProperties)).toEqual(response)
+    })
+  })
+})

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -190,7 +190,7 @@ describe('testing POST object', () => {
     expect(response.body).toBe(
       JSON.stringify({
         statusCode: '42501',
-        error: '',
+        error: null,
         message: 'new row violates row-level security policy for table "objects"',
       })
     )

--- a/src/utils/generic-routes.ts
+++ b/src/utils/generic-routes.ts
@@ -1,0 +1,37 @@
+type BucketResponseType = { message: string; statusCode?: string; error?: string }
+
+/**
+ * Create generic respose for all buckets
+ * @param message {string} Main message
+ * @param status {string=} StatusCode
+ * @param error {string=} Error number (presented as a string)
+ * @return {BucketResponseType} Object with all paramaters
+ */
+function createResponse(message: string, status?: string, error?: string): BucketResponseType {
+  const response: BucketResponseType = {
+    message,
+  }
+
+  if (status) {
+    response.statusCode = status
+  }
+
+  if (error) {
+    response.error = error
+  }
+
+  return response
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createDefaultSchema(successResponseSchema: any, properties: any): any {
+  return {
+    schema: {
+      headers: { $ref: 'authSchema#' },
+      response: { 200: successResponseSchema, '4xx': { $ref: 'errorSchema#' } },
+      ...properties,
+    },
+  }
+}
+
+export { createResponse, createDefaultSchema }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- refactor: create two generic methods and use them to avoid repetition

**Note:** There is still a lot of repetition, especially on routes, but this pull-request can help remove duplication

## What is the current behavior?
## What is the new behavior?

Both behaviours remain the same.

## Additional context

> The open-source community is incredible!

**Note:** Sorry for the extensive pull-request...