### PR TITLE
Feat/support binary and stream uploads

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import fastifyMultipart from 'fastify-multipart'
 import fastifySwagger from 'fastify-swagger'
+import { createWriteStream } from 'fs'
 import bucketRoutes from './routes/bucket/'
 import objectRoutes from './routes/object'
 import { authSchema } from './schemas/auth'
@@ -20,6 +21,10 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
       fileSize: fileSizeLimit,
       files: 1,
     },
+  })
+
+  app.addContentTypeParser('*', function (request, payload, done) {
+    done(null)
   })
 
   // kong should take care of cors

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import fastifyMultipart from 'fastify-multipart'
 import fastifySwagger from 'fastify-swagger'
-import { createWriteStream } from 'fs'
 import bucketRoutes from './routes/bucket/'
 import objectRoutes from './routes/object'
 import { authSchema } from './schemas/auth'

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -58,7 +58,7 @@ export default async function routes(fastify: FastifyInstance) {
       const jwt = authHeader.substring('Bearer '.length)
 
       const contentType = request.headers['content-type']
-      console.log(contentType)
+      request.log.info(`content-type is ${contentType}`)
 
       const { bucketName } = request.params
       const objectName = request.params['*']
@@ -148,10 +148,8 @@ export default async function routes(fastify: FastifyInstance) {
         )
         const { fileSizeLimit } = getConfig()
         // @todo more secure to get this from the stream or from s3 in the next step
-        console.log('comparing', Number(request.headers['content-length']), fileSizeLimit)
         isTruncated = Number(request.headers['content-length']) > fileSizeLimit
       }
-      console.log('trunc', isTruncated)
       if (isTruncated) {
         // undo operations as super user
         await superUserPostgrest


### PR DESCRIPTION
`createObject` supports both `FormData` via a `multipart/form-data` content-type and a binary upload via the POST body. 

If using the binary upload, the mimeType and cacheControl should be sent via the `content-type` and `cache-control` headers (This is where a multipart upload is cleaner but since formdata is not supported in Node, had to implement this)

Backend support for https://github.com/supabase/storage-js/issues/5

From Node, you can do
```js
const MY_FILE_PATH = "image-stream.jpg";
const fs = require("fs");
const axios = require("axios");

const readmeStream = fs.createReadStream(MY_FILE_PATH);
readmeStream.on("error", console.log);
const { size } = fs.statSync(MY_FILE_PATH);

axios({
  method: "POST",
  url: `http://localhost:5000/object/bucket2/${MY_FILE_PATH}`,
  headers: {
    "Content-Type": "image/jpeg",
    "Content-Length": size,
    Authorization:
      "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...,
  },
  data: readmeStream,
});
```

Or directly send a buffer
```js
const MY_FILE_PATH = "image-stream.jpg";
const fs = require("fs");
const axios = require("axios");

const { size } = fs.statSync(MY_FILE_PATH);

axios({
  method: "POST",
  url: `http://localhost:5000/object/bucket2/${MY_FILE_PATH}`,
  headers: {
    "Content-Type": "image/jpeg",
    "Content-Length": size,
    Authorization:
      "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
  },
  data: fs.readFileSync(MY_FILE_PATH),
});
```

From Browser you can do the same thing via a File Object without using FormData