### PR TITLE
Fix: file size limit check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
       fileSize: fileSizeLimit,
       files: 1,
     },
+    throwFileSizeLimit: false,
   })
 
   // kong should take care of cors


### PR DESCRIPTION
The api for fastify-multipart changed somewhere in between and this option needs to be passed in to change to the old behaviour