### PR TITLE
fix: #43 use custom content type parser for application/json and text/plain

### DIFF
--- a/src/routes/bucket/index.ts
+++ b/src/routes/bucket/index.ts
@@ -8,10 +8,10 @@ import updateBucket from './updateBucket'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
-  createBucket(fastify)
-  deleteBucket(fastify)
-  emptyBucket(fastify)
-  getAllBuckets(fastify)
-  getBucket(fastify)
-  updateBucket(fastify)
+  fastify.register(createBucket)
+  fastify.register(deleteBucket)
+  fastify.register(emptyBucket)
+  fastify.register(getAllBuckets)
+  fastify.register(getBucket)
+  fastify.register(updateBucket)
 }

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -49,6 +49,13 @@ export default async function routes(fastify: FastifyInstance) {
     tags: ['object'],
   })
 
+  fastify.addContentTypeParser(
+    ['application/json', 'text/plain'],
+    function (request, payload, done) {
+      done(null)
+    }
+  )
+
   fastify.post<createObjectRequestInterface>(
     '/:bucketName/*',
     {

--- a/src/routes/object/index.ts
+++ b/src/routes/object/index.ts
@@ -13,15 +13,15 @@ import updateObject from './updateObject'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function routes(fastify: FastifyInstance) {
-  copyObject(fastify)
-  createObject(fastify)
-  deleteObject(fastify)
-  deleteObjects(fastify)
-  getObject(fastify)
-  getSignedObject(fastify)
-  getPublicObject(fastify)
-  getSignedURL(fastify)
-  moveObject(fastify)
-  updateObject(fastify)
-  listObjects(fastify)
+  fastify.register(copyObject)
+  fastify.register(createObject)
+  fastify.register(deleteObject)
+  fastify.register(deleteObjects)
+  fastify.register(getObject)
+  fastify.register(getSignedObject)
+  fastify.register(getPublicObject)
+  fastify.register(getSignedURL)
+  fastify.register(moveObject)
+  fastify.register(updateObject)
+  fastify.register(listObjects)
 }

--- a/src/routes/object/updateObject.ts
+++ b/src/routes/object/updateObject.ts
@@ -44,6 +44,14 @@ export default async function routes(fastify: FastifyInstance) {
     summary,
     tags: ['object'],
   })
+
+  fastify.addContentTypeParser(
+    ['application/json', 'text/plain'],
+    function (request, payload, done) {
+      done(null)
+    }
+  )
+
   fastify.put<updateObjectRequestInterface>(
     '/:bucketName/*',
     {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Pipe the request stream for these content types instead of the default handling. See https://www.fastify.io/docs/latest/ContentTypeParser/.

## What is the current behavior?

`text/plain` and `application/json` MIME type are uploaded in Storage Buckets as empty files.

## What is the new behavior?

`text/plain` and `application/json` MIME type are uploaded in Storage Buckets correctly.