### PR TITLE
fix: xattr no longer required in release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,8 @@ jobs:
           npm run pkg -- --targets node14-linux-x64,node14-macos-x64 --out-path bin
           mv bin/server-macos storage-api-macos-x86_64
           mv bin/server-linux storage-api-x86_64
-          cp node_modules/fs-xattr/build/Release/xattr.node .
-          tar -czvf storage-api-linux-x64.tar.gz storage-api-x86_64 migrations/ xattr.node
-          tar -czvf storage-api-macos-x64.tar.gz storage-api-macos-x86_64 migrations/ xattr.node
+          tar -czvf storage-api-linux-x64.tar.gz storage-api-x86_64 migrations/
+          tar -czvf storage-api-macos-x64.tar.gz storage-api-macos-x86_64 migrations/
       - name: Upload x64 binary to release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -118,9 +117,8 @@ jobs:
             . ~/.nvm/nvm.sh
             npm ci
             npm run build
-            cp node_modules/fs-xattr/build/Release/xattr.node .
             npm run pkg -- --targets node14-linux-arm64 --output storage-api-aarch64
-            tar -czvf storage-api-aarch64.tar.gz storage-api-aarch64 migrations/ xattr.node
+            tar -czvf storage-api-aarch64.tar.gz storage-api-aarch64 migrations/
             cp storage-api-aarch64.tar.gz /artifacts/storage-api-aarch64.tar.gz
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2

--- a/gh-Dockerfile
+++ b/gh-Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /root/storage
 
 COPY storage-api-x86_64 .
 COPY migrations ./migrations
-COPY xattr.node .
 
 ENTRYPOINT "./storage-api-x86_64"
 EXPOSE 5000


### PR DESCRIPTION
recent version of pkg seems to handle bundling xattr.node in the binary well