### PR TITLE
Fix: 499 errors

### DIFF
--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -7,6 +7,7 @@ import {
   S3Client,
   S3ClientConfig,
 } from '@aws-sdk/client-s3'
+import https from 'https'
 import { Upload } from '@aws-sdk/lib-storage'
 import { NodeHttpHandler } from '@aws-sdk/node-http-handler'
 import { ObjectMetadata, ObjectResponse } from '../types/types'
@@ -16,10 +17,15 @@ export class S3Backend implements GenericStorageBackend {
   client: S3Client
 
   constructor(region: string, endpoint?: string | undefined) {
+    const agent = new https.Agent({
+      maxSockets: 50,
+      keepAlive: true,
+    })
     const params: S3ClientConfig = {
       region,
       runtime: 'node',
       requestHandler: new NodeHttpHandler({
+        httpsAgent: agent,
         socketTimeout: 3000,
       }),
     }
@@ -36,7 +42,6 @@ export class S3Backend implements GenericStorageBackend {
       Range: range,
     })
     const data = await this.client.send(command)
-    data.Body
     return {
       metadata: {
         cacheControl: data.CacheControl,

--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -20,7 +20,7 @@ export class S3Backend implements GenericStorageBackend {
       region,
       runtime: 'node',
       requestHandler: new NodeHttpHandler({
-        socketTimeout: 300000,
+        socketTimeout: 3000,
       }),
     }
     if (endpoint) {

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -91,7 +91,7 @@ export default async function routes(fastify: FastifyInstance) {
         } else {
           return response.status(400).send({
             message: err.message,
-            statusCode: err.$metadata?.httpStatusCode,
+            statusCode: '400',
             error: err.message,
           })
         }

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -86,6 +86,7 @@ export default async function routes(fastify: FastifyInstance) {
         }
         return response.send(data.body)
       } catch (err) {
+        request.log.error(err)
         if (err.$metadata?.httpStatusCode === 404) {
           return response.status(404).send()
         } else {


### PR DESCRIPTION
when client aborted a request to storage server, it kept the socket open for 300 seconds. S3 SDK couldn't open any more sockets after there were 50 open idle sockets (which is the default). 

This PR reduces the socket idle timeout from 300 seconds to 3 seconds and explicitly shows the maxsockets parameter so that it can be finetuned later

fixes https://github.com/supabase/infrastructure/issues/1064