### PR TITLE
Add 1s connection timeout for migration database client

### DIFF
--- a/src/utils/migrate.ts
+++ b/src/utils/migrate.ts
@@ -11,6 +11,7 @@ async function connectAndMigrate(
 ) {
   const dbConfig = {
     connectionString: databaseUrl,
+    connectionTimeoutMillis: 1000,
   }
   const client = new Client(dbConfig)
   try {


### PR DESCRIPTION
Migration was throwing "connect ETIMEDOUT" errors only after ~2 mins.