### PR TITLE
fix extension function by getting the last item of a split

### DIFF
--- a/src/test/db/02-storage-schema.sql
+++ b/src/test/db/02-storage-schema.sql
@@ -71,7 +71,7 @@ BEGIN
 	select string_to_array(name, '/') into _parts;
 	select _parts[array_length(_parts,1)] into _filename;
 	-- @todo return the last part instead of 2
-	return split_part(_filename, '.', 2);
+	return reverse(split_part(reverse(_filename), '.', 1));
 END
 $function$;
 


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...
Bug fix #12

## What is the current behavior?

We assume that the name of the file is `cat.jpg`, getting the extension is by getting the second index of the split by '.'.
However, files can have multiple '.', hence this PR introduces a more general implementation.

Please link any relevant issues here.

## What is the new behavior?

Reverse the string, split it by '.' and get the first item, reverse the string again. We'll get the last index of the split '.'.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
