### PR TITLE
make migration idempotent

### DIFF
--- a/migrations/tenant/0007-add-public-to-buckets.sql
+++ b/migrations/tenant/0007-add-public-to-buckets.sql
@@ -1,1 +1,1 @@
-ALTER TABLE storage.buckets ADD COLUMN "public" boolean default false;
+ALTER TABLE storage.buckets ADD COLUMN IF NOT EXISTS "public" boolean default false;


### PR DESCRIPTION
so that the server can continue startup in case the migration was already run