### PR TITLE
fix: revert "make migration idempotent"

### DIFF
--- a/migrations/tenant/0007-add-public-to-buckets.sql
+++ b/migrations/tenant/0007-add-public-to-buckets.sql
@@ -1,1 +1,1 @@
-ALTER TABLE storage.buckets ADD COLUMN IF NOT EXISTS "public" boolean default false;
+ALTER TABLE storage.buckets ADD COLUMN "public" boolean default false;


### PR DESCRIPTION
This reverts commit 47b12abd40a6355f79d47bf17b8ce00e9b2a2d14, which is causing error "Migration failed. Reason: Hashes don't match for migrations '0007-add-public-to-buckets.sql'. This means that the scripts have changed since it was applied."