### PR TITLE
feat: add endpoint to get signed URLs

### DIFF
--- a/src/routes/object/getSignedURLs.ts
+++ b/src/routes/object/getSignedURLs.ts
@@ -1,0 +1,119 @@
+import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
+import { AuthenticatedRequest, Obj } from '../../types/types'
+import { getJwtSecret, signJWT, transformPostgrestError } from '../../utils'
+import { createDefaultSchema, createResponse } from '../../utils/generic-routes'
+
+const getSignedURLsParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', example: 'avatars' },
+  },
+  required: ['bucketName'],
+} as const
+const getSignedURLsBodySchema = {
+  type: 'object',
+  properties: {
+    expiresIn: { type: 'integer', minimum: 1, example: 60000 },
+    prefixes: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      maxItems: 1000,
+      example: ['folder/cat.png', 'folder/morecats.png'],
+    },
+  },
+  required: ['expiresIn', 'prefixes'],
+} as const
+const successResponseSchema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      prefix: {
+        type: 'string',
+        example: 'folder/cat.png',
+      },
+      signedURL: {
+        type: 'string',
+        example:
+          '/object/sign/avatars/folder/cat.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJhdmF0YXJzL2ZvbGRlci9jYXQucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.s7Gt8ME80iREVxPhH01ZNv8oUn4XtaWsmiQ5csiUHn4',
+      },
+    },
+    required: ['signedURL'],
+  },
+}
+interface getSignedURLsRequestInterface extends AuthenticatedRequest {
+  Params: FromSchema<typeof getSignedURLsParamsSchema>
+  Body: FromSchema<typeof getSignedURLsBodySchema>
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Generate presigned urls to retrieve objects'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: getSignedURLsBodySchema,
+    params: getSignedURLsParamsSchema,
+    summary,
+    tags: ['object'],
+  })
+
+  fastify.post<getSignedURLsRequestInterface>(
+    '/sign/:bucketName',
+    {
+      schema,
+    },
+    async (request, response) => {
+      const { bucketName } = request.params
+      const { expiresIn, prefixes } = request.body
+
+      const objectResponse = await request.postgrest
+        .from<Obj>('objects')
+        .select('name')
+        .eq('bucket_id', bucketName)
+        .in('name', prefixes)
+
+      if (objectResponse.error) {
+        const { error, status } = objectResponse
+        request.log.error({ error }, 'error object')
+        return response.status(400).send(transformPostgrestError(error, status))
+      }
+
+      const { data: results } = objectResponse
+      request.log.info({ results }, 'results')
+
+      const nameSet = new Set(results.map(({ name }) => name))
+      const difference = [...new Set(prefixes)].filter((prefix) => !nameSet.has(prefix))
+
+      if (difference.length > 0) {
+        return response
+          .status(400)
+          .send(
+            createResponse(
+              `Either the objects do not exist or you do not have access to: ${difference.join(
+                ' ,'
+              )}`,
+              '400',
+              'Non-existent or no access'
+            )
+          )
+      }
+
+      const jwtSecret = await getJwtSecret(request.tenantId)
+      const signedUrls = await Promise.all(
+        prefixes.map(async (prefix) => {
+          const urlToSign = `${bucketName}/${prefix}`
+          request.log.info(`going to sign ${urlToSign}`)
+          const token = await signJWT({ url: urlToSign }, jwtSecret, expiresIn)
+          return {
+            prefix,
+            signedURL: `/object/sign/${urlToSign}?token=${token}`,
+          }
+        })
+      )
+
+      return response.status(200).send(signedUrls)
+    }
+  )
+}

--- a/src/routes/object/getSignedURLs.ts
+++ b/src/routes/object/getSignedURLs.ts
@@ -76,7 +76,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       if (objectResponse.error) {
         const { error, status } = objectResponse
-        request.log.error({ error }, 'error object')
+        request.log.error({ error }, 'failed to retrieve object names while getting signed URLs')
         return response.status(400).send(transformPostgrestError(error, status))
       }
 

--- a/src/routes/object/getSignedURLs.ts
+++ b/src/routes/object/getSignedURLs.ts
@@ -104,7 +104,6 @@ export default async function routes(fastify: FastifyInstance) {
       const signedUrls = await Promise.all(
         prefixes.map(async (prefix) => {
           const urlToSign = `${bucketName}/${prefix}`
-          request.log.info(`going to sign ${urlToSign}`)
           const token = await signJWT({ url: urlToSign }, jwtSecret, expiresIn)
           return {
             prefix,

--- a/src/routes/object/index.ts
+++ b/src/routes/object/index.ts
@@ -9,6 +9,7 @@ import getObject from './getObject'
 import getPublicObject from './getPublicObject'
 import getSignedObject from './getSignedObject'
 import getSignedURL from './getSignedURL'
+import getSignedURLs from './getSignedURLs'
 import listObjects from './listObjects'
 import moveObject from './moveObject'
 import updateObject from './updateObject'
@@ -23,6 +24,7 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(deleteObjects)
     fastify.register(getObject)
     fastify.register(getSignedURL)
+    fastify.register(getSignedURLs)
     fastify.register(moveObject)
     fastify.register(updateObject)
     fastify.register(listObjects)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
@@ -11,15 +12,10 @@
     "strict": true,
     "lib": ["ES6", "DOM"]
   },
-  "include": [
-    "./src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ],
-  "parserOptions":  {
-    "ecmaVersion":  "2020",  // Allows for the parsing of modern ECMAScript features
-    "sourceType":  "module"  // Allows for the use of imports
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "parserOptions": {
+    "ecmaVersion": "2020", // Allows for the parsing of modern ECMAScript features
+    "sourceType": "module" // Allows for the use of imports
   }
 }


### PR DESCRIPTION
@inian I'm using `prefixes` for consistency with the other batch API: https://github.com/supabase/storage-api/blob/fd072d448f3d860ad5f404406c7f09c025826206/src/routes/object/deleteObjects.ts#L31. However, we aren't using those strings as prefixes there, and aren't doing so here either. Do you recall why they're named `prefixes`, should we rename to say, `paths`, and be inconsistent with the delete objects endpoint?