### PR TITLE
fix: only cache tenant configurations and run migrations after servers start listening

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,6 @@ const exposeDocs = true
   const { isMultitenant } = getConfig()
   if (isMultitenant) {
     await runMultitenantMigrations()
-    await cacheTenantConfigsFromDbAndRunMigrations()
     await listenForTenantUpdate()
 
     const adminApp: FastifyInstance<Server, IncomingMessage, ServerResponse> = buildAdmin({
@@ -52,4 +51,8 @@ const exposeDocs = true
     }
     console.log(`Server listening at ${address}`)
   })
+
+  if (isMultitenant) {
+    await cacheTenantConfigsFromDbAndRunMigrations()
+  }
 })()


### PR DESCRIPTION
Running migrations for all tenants is taking too long on startup. We cache tenant configurations and run migrations on demand if the tenant configuration isn’t already cached, doing that on startup is just a performance optimisation, which can be delayed.