### PR TITLE
fix: include `pg-format/lib/reserved.js` in `pkg` `assets`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm run pkg -- --targets node14-linux-x64,node14-macos-x64 --out-path bin
+          npm run pkg
           mv bin/server-macos storage-api-macos-x86_64
           mv bin/server-linux storage-api-x86_64
           tar -czvf storage-api-linux-x64.tar.gz storage-api-x86_64 migrations/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 !.*.sample
 static/api.json
 data/
+bin/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --log-error --files ./src/server.ts",
     "build": "tsc -p tsconfig.json",
-    "pkg": "pkg dist/server.js",
+    "pkg": "pkg .",
     "start": "NODE_ENV=production node dist/server.js",
     "migration:run": "ts-node-dev ./src/scripts/migrate-call.ts",
     "docs:export": "ts-node-dev ./src/scripts/export-docs.ts",
@@ -68,5 +68,14 @@
     "ts-jest": "^27.1.3",
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.5.5"
+  },
+  "bin": "./dist/server.js",
+  "pkg": {
+    "assets": "node_modules/pg-format/lib/reserved.js",
+    "outputPath": "bin",
+    "targets": [
+      "node14-linux-x64",
+      "node14-macos-x64"
+    ]
   }
 }


### PR DESCRIPTION
Fixes:

```
pkg/prelude/bootstrap.js:1740
      throw error;
      ^

Error: Cannot find module '/snapshot/storage-api/node_modules/pg-format/lib/reserved.js'
Require stack:
- /snapshot/storage-api/node_modules/pg-format/lib/index.js
- /snapshot/storage-api/node_modules/pg-listen/dist/index.js
- /snapshot/storage-api/node_modules/pg-listen/index.js
- /snapshot/storage-api/dist/utils/tenant.js
- /snapshot/storage-api/dist/plugins/postgrest.js
- /snapshot/storage-api/dist/routes/bucket/index.js
- /snapshot/storage-api/dist/app.js
- /snapshot/storage-api/dist/server.js
1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function._resolveFilename (pkg/prelude/bootstrap.js:1819:46)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Module.require (pkg/prelude/bootstrap.js:1719:31)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/snapshot/storage-api/node_modules/pg-format/lib/index.js:4:19)
    at Module._compile (pkg/prelude/bootstrap.js:1794:22)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/snapshot/storage-api/node_modules/pg-format/lib/index.js',
    '/snapshot/storage-api/node_modules/pg-listen/dist/index.js',
    '/snapshot/storage-api/node_modules/pg-listen/index.js',
    '/snapshot/storage-api/dist/utils/tenant.js',
    '/snapshot/storage-api/dist/plugins/postgrest.js',
    '/snapshot/storage-api/dist/routes/bucket/index.js',
    '/snapshot/storage-api/dist/app.js',
    '/snapshot/storage-api/dist/server.js'
  ],
  pkg: true
}
```