### PR TITLE
feat: add ability to search files and folders by prefix

### DIFF
--- a/migrations/tenant/0009-search-files-search-function.sql
+++ b/migrations/tenant/0009-search-files-search-function.sql
@@ -1,0 +1,69 @@
+drop function storage.search;
+
+create or replace function storage.search (
+  prefix text,
+  bucketname text,
+  limits int default 100,
+  levels int default 1,
+  offsets int default 0,
+  search text default '',
+  sortcolumn text default 'name',
+  sortorder text default 'asc'
+) returns table (
+    name text,
+    id uuid,
+    updated_at timestamptz,
+    created_at timestamptz,
+    last_accessed_at timestamptz,
+    metadata jsonb
+  )
+as $$
+declare
+  v_order_by text;
+begin
+  case
+    when sortcolumn = 'name' then
+      v_order_by = 'name';
+    when sortcolumn = 'updated_at' then
+      v_order_by = 'updated_at';
+    when sortcolumn = 'created_at' then
+      v_order_by = 'created_at';
+    when sortcolumn = 'last_accessed_at' then
+      v_order_by = 'last_accessed_at';
+    else
+      v_order_by = 'name';
+  end case;
+
+  case
+    when sortorder = 'asc' then
+      v_order_by = v_order_by || ' asc';
+    when sortorder = 'desc' then
+      v_order_by = v_order_by || ' desc';
+    else
+      v_order_by = v_order_by || ' asc';
+  end case;
+
+  return query execute
+    'select p.name,
+            p.id,
+            p.updated_at,
+            p.created_at,
+            p.last_accessed_at,
+            p.metadata
+     from (
+       select o.path_tokens[$1] as "name",
+              o.id,
+              o.updated_at,
+              o.created_at,
+              o.last_accessed_at,
+              o.metadata,
+              array_length(regexp_split_to_array(o.name, ''/''), 1) = $1 as is_file
+       from storage.objects o
+       where o.name ilike $2 || $3 || ''%''
+       and o.bucket_id = $4
+       order by is_file, ' || v_order_by || '
+       limit $5
+       offset $6
+     ) p;' using levels, prefix, search, bucketname, limits, offsets;
+end;
+$$ language plpgsql stable;

--- a/src/routes/object/listObjects.ts
+++ b/src/routes/object/listObjects.ts
@@ -26,6 +26,9 @@ const searchRequestBodySchema = {
       },
       required: ['column'],
     },
+    search: {
+      type: 'string',
+    },
   },
   required: ['prefix'],
 } as const
@@ -55,7 +58,7 @@ export default async function routes(fastify: FastifyInstance) {
     },
     async (request, response) => {
       const { bucketName } = request.params
-      const { limit, offset, sortBy } = request.body
+      const { limit, offset, sortBy, search } = request.body
       let sortColumn, sortOrder
       if (sortBy?.column) {
         sortColumn = sortBy.column
@@ -76,17 +79,16 @@ export default async function routes(fastify: FastifyInstance) {
         data: results,
         error,
         status,
-      } = await request.postgrest
-        .rpc('search', {
-          prefix,
-          bucketname: bucketName,
-          limits: limit,
-          offsets: offset,
-          levels: prefix.split('/').length,
-        })
-        .order(sortColumn, {
-          ascending: sortOrder === 'asc',
-        })
+      } = await request.postgrest.rpc('search', {
+        prefix,
+        bucketname: bucketName,
+        limits: limit,
+        offsets: offset,
+        levels: prefix.split('/').length,
+        search,
+        sortcolumn: sortColumn,
+        sortorder: sortOrder,
+      })
 
       if (error) {
         request.log.error({ error }, 'search rpc')


### PR DESCRIPTION
Adds an optional `search` parameter to the search function, which can be used to search for files and folders within a given folder (`prefix`).

This new function is compatible (other than the order in which items are returned) with the previous version, so there shouldn't be any breaking changes.

Additionally, sorts by folders first, then files.