### PR TITLE
fix: remove `under-pressure` `maxEventLoopUtilization` check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(logTenantId)
   app.register(bucketRoutes, { prefix: 'bucket' })
   app.register(objectRoutes, { prefix: 'object' })
-  app.register(underPressure, { exposeStatusRoute: true, maxEventLoopUtilization: 0.99 })
+  app.register(underPressure, { exposeStatusRoute: true })
 
   return app
 }


### PR DESCRIPTION
In a recent incident, the `maxEventLoopUtilization` check led to 503's being returned for all requests even though the requests were being processed, albeit intermittently, in spurts of every half to one second. We should instead continue to process requests and rely on Auto Scaling. Without any checks, `under-pressure` is simply exposing a `/status` route, but it ain't broke.
