### PR TITLE
fix: remove under-pressure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,7 @@
         "pg-listen": "^1.7.0",
         "pino": "^7.8.0",
         "pkg": "^5.5.2",
-        "postgres-migrations": "^5.3.0",
-        "under-pressure": "^5.8.0"
+        "postgres-migrations": "^5.3.0"
       },
       "bin": {
         "supa-storage": "dist/server.js"
@@ -8817,18 +8816,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/under-pressure": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/under-pressure/-/under-pressure-5.8.0.tgz",
-      "integrity": "sha512-8ADLZkFEGDAsKof1FEICH/OLyGWjDZy6KR/Exq3MTv7W81zC2W23VekY05Fo350lip1ywYNH9wP7itiVnk4wHg==",
-      "dependencies": {
-        "fastify-error": "^0.3.0",
-        "fastify-plugin": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -15956,15 +15943,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
-    },
-    "under-pressure": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/under-pressure/-/under-pressure-5.8.0.tgz",
-      "integrity": "sha512-8ADLZkFEGDAsKof1FEICH/OLyGWjDZy6KR/Exq3MTv7W81zC2W23VekY05Fo350lip1ywYNH9wP7itiVnk4wHg==",
-      "requires": {
-        "fastify-error": "^0.3.0",
-        "fastify-plugin": "^3.0.0"
-      }
     },
     "universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "pg-listen": "^1.7.0",
     "pino": "^7.8.0",
     "pkg": "^5.5.2",
-    "postgres-migrations": "^5.3.0",
-    "under-pressure": "^5.8.0"
+    "postgres-migrations": "^5.3.0"
   },
   "devDependencies": {
     "@types/busboy": "^1.3.0",

--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -1,11 +1,10 @@
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
-import underPressure from 'under-pressure'
 import tenantRoutes from './routes/tenant'
 
 const build = (opts: FastifyServerOptions = {}): FastifyInstance => {
   const app = fastify(opts)
   app.register(tenantRoutes, { prefix: 'tenants' })
-  app.register(underPressure, { exposeStatusRoute: true, maxEventLoopUtilization: 0.99 })
+  app.get('/status', async (request, response) => response.status(200).send())
   return app
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import fastifyMultipart from 'fastify-multipart'
 import fastifySwagger from 'fastify-swagger'
-import underPressure from 'under-pressure'
 import bucketRoutes from './routes/bucket/'
 import objectRoutes from './routes/object'
 import { authSchema } from './schemas/auth'
@@ -55,7 +54,8 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(logTenantId)
   app.register(bucketRoutes, { prefix: 'bucket' })
   app.register(objectRoutes, { prefix: 'object' })
-  app.register(underPressure, { exposeStatusRoute: true })
+
+  app.get('/status', async (request, response) => response.status(200).send())
 
   return app
 }


### PR DESCRIPTION
`maxEventLoopUtilization: 0.99` should have been removed for the admin app. under-pressure had been retained since it was already exposing a working status route, but might as well remove it if that's all it does.