### PR TITLE
fix: reduce object deletion batch size when emptying bucket from 500 to 300

### DIFF
--- a/src/routes/bucket/emptyBucket.ts
+++ b/src/routes/bucket/emptyBucket.ts
@@ -71,7 +71,7 @@ export default async function routes(fastify: FastifyInstance) {
           .from<Obj>('objects')
           .select('name, id')
           .eq('bucket_id', bucketId)
-          .limit(500)
+          .limit(300)
 
         if (objectError) {
           request.log.error({ error: objectError }, 'error object')


### PR DESCRIPTION
The current batch size can cause 414 URI too long errors when the PostgREST URL for deletion is more than 16K in length. 16K is the default for Kong/NGINX. Each object adds UUID length (36) + "%2C" (3) to the URL. 39*300=12K, well below 16K.