### PR TITLE
Support for optional S3 credentials

### DIFF
--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -17,7 +17,7 @@ import { GenericStorageBackend, GetObjectHeaders } from './generic'
 export class S3Backend implements GenericStorageBackend {
   client: S3Client
 
-  constructor(region: string, endpoint?: string | undefined) {
+  constructor(region: string, endpoint?: string | undefined, accessKeyId?: string | undefined, secretAccessKey?: string | undefined) {
     const agent = new https.Agent({
       maxSockets: 50,
       keepAlive: true,
@@ -32,6 +32,9 @@ export class S3Backend implements GenericStorageBackend {
     }
     if (endpoint) {
       params.endpoint = endpoint
+    }
+    if (accessKeyId != undefined && secretAccessKey != undefined) {
+      params.credentials = { accessKeyId: accessKeyId, secretAccessKey: secretAccessKey }
     }
     this.client = new S3Client(params)
   }

--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -17,7 +17,12 @@ import { GenericStorageBackend, GetObjectHeaders } from './generic'
 export class S3Backend implements GenericStorageBackend {
   client: S3Client
 
-  constructor(region: string, endpoint?: string | undefined, accessKeyId?: string | undefined, secretAccessKey?: string | undefined) {
+  constructor(
+    region: string,
+    endpoint?: string | undefined,
+    accessKeyId?: string | undefined,
+    secretAccessKey?: string | undefined
+  ) {
     const agent = new https.Agent({
       maxSockets: 50,
       keepAlive: true,

--- a/src/routes/bucket/emptyBucket.ts
+++ b/src/routes/bucket/emptyBucket.ts
@@ -8,13 +8,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 const emptyBucketParamsSchema = {
   type: 'object',

--- a/src/routes/object/copyObject.ts
+++ b/src/routes/object/copyObject.ts
@@ -8,13 +8,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const copyRequestBodySchema = {

--- a/src/routes/object/copyObject.ts
+++ b/src/routes/object/copyObject.ts
@@ -8,13 +8,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const copyRequestBodySchema = {

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -15,13 +15,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const createObjectParamsSchema = {

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -15,13 +15,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const createObjectParamsSchema = {

--- a/src/routes/object/deleteObject.ts
+++ b/src/routes/object/deleteObject.ts
@@ -8,13 +8,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const deleteObjectParamsSchema = {

--- a/src/routes/object/deleteObject.ts
+++ b/src/routes/object/deleteObject.ts
@@ -8,13 +8,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const deleteObjectParamsSchema = {

--- a/src/routes/object/deleteObjects.ts
+++ b/src/routes/object/deleteObjects.ts
@@ -9,13 +9,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const deleteObjectsParamsSchema = {

--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -10,13 +10,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const getObjectParamsSchema = {

--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -10,13 +10,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const getObjectParamsSchema = {

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -8,13 +8,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const getPublicObjectParamsSchema = {

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -8,13 +8,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const getPublicObjectParamsSchema = {

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -9,13 +9,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const getSignedObjectParamsSchema = {

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -9,13 +9,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const getSignedObjectParamsSchema = {

--- a/src/routes/object/moveObject.ts
+++ b/src/routes/object/moveObject.ts
@@ -8,13 +8,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const moveObjectsBodySchema = {

--- a/src/routes/object/moveObject.ts
+++ b/src/routes/object/moveObject.ts
@@ -8,13 +8,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const moveObjectsBodySchema = {

--- a/src/routes/object/updateObject.ts
+++ b/src/routes/object/updateObject.ts
@@ -14,13 +14,13 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint)
+  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
 }
 
 const updateObjectParamsSchema = {

--- a/src/routes/object/updateObject.ts
+++ b/src/routes/object/updateObject.ts
@@ -14,13 +14,25 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, globalS3AccessKeyId, globalS3SecretAccessKey } = getConfig()
+const {
+  region,
+  globalS3Bucket,
+  globalS3Endpoint,
+  storageBackendType,
+  globalS3AccessKeyId,
+  globalS3SecretAccessKey,
+} = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
   storageBackend = new FileBackend()
 } else {
-  storageBackend = new S3Backend(region, globalS3Endpoint, globalS3AccessKeyId, globalS3SecretAccessKey)
+  storageBackend = new S3Backend(
+    region,
+    globalS3Endpoint,
+    globalS3AccessKeyId,
+    globalS3SecretAccessKey
+  )
 }
 
 const updateObjectParamsSchema = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,7 +20,9 @@ type StorageConfigType = {
   serviceKey: string
   storageBackendType: StorageBackendType
   tenantId: string
-  xForwardedHostRegExp?: string
+  xForwardedHostRegExp?: string,
+  globalS3AccessKeyId?: string,
+  globalS3SecretAccessKey?: string,
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -66,6 +68,8 @@ export function getConfig(): StorageConfigType {
       getOptionalConfigFromEnv('PROJECT_REF') ||
       getOptionalIfMultitenantConfigFromEnv('TENANT_ID') ||
       '',
+    globalS3AccessKeyId: getOptionalConfigFromEnv('GLOBAL_S3_ACCESS_KEY_ID'),
+    globalS3SecretAccessKey: getOptionalConfigFromEnv('GLOBAL_S3_SECRET_ACCESS_KEY'),
     xForwardedHostRegExp: getOptionalConfigFromEnv('X_FORWARDED_HOST_REGEXP'),
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Unable to connect to non AWS S3 storage that requires the [Credentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#credentials) object to be included in the `S3ClientConfig`.

## What is the new behavior?
Allow passing in `access key ID` and `secret access key` as optional environment variables and then include them as the `Credentials` object in the `S3ClientConfig` if present.

## Additional context

Add any other context or screenshots.
