### PR TITLE
fix: limit URL length when getting signed URLs, deleting objects and emptying bucket

### DIFF
--- a/src/routes/bucket/emptyBucket.ts
+++ b/src/routes/bucket/emptyBucket.ts
@@ -8,7 +8,7 @@ import { S3Backend } from '../../backend/s3'
 import { FileBackend } from '../../backend/file'
 import { GenericStorageBackend } from '../../backend/generic'
 
-const { region, globalS3Bucket, globalS3Endpoint, storageBackendType } = getConfig()
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, urlLengthLimit } = getConfig()
 let storageBackend: GenericStorageBackend
 
 if (storageBackendType === 'file') {
@@ -71,7 +71,7 @@ export default async function routes(fastify: FastifyInstance) {
           .from<Obj>('objects')
           .select('name, id')
           .eq('bucket_id', bucketId)
-          .limit(300)
+          .limit(Math.floor(urlLengthLimit / (36 + 3))) // UUID + %2C lengths
 
         if (objectError) {
           request.log.error({ error: objectError }, 'error object')

--- a/src/routes/object/getSignedURLs.ts
+++ b/src/routes/object/getSignedURLs.ts
@@ -2,7 +2,10 @@ import { FastifyInstance } from 'fastify'
 import { FromSchema } from 'json-schema-to-ts'
 import { AuthenticatedRequest, Obj } from '../../types/types'
 import { getJwtSecret, signJWT, transformPostgrestError } from '../../utils'
-import { createDefaultSchema, createResponse } from '../../utils/generic-routes'
+import { getConfig } from '../../utils/config'
+import { createDefaultSchema } from '../../utils/generic-routes'
+
+const { urlLengthLimit } = getConfig()
 
 const getSignedURLsParamsSchema = {
   type: 'object',
@@ -19,7 +22,6 @@ const getSignedURLsBodySchema = {
       type: 'array',
       items: { type: 'string' },
       minItems: 1,
-      maxItems: 1000,
       example: ['folder/cat.png', 'folder/morecats.png'],
     },
   },
@@ -71,21 +73,33 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketName } = request.params
       const { expiresIn, paths } = request.body
+      let results: { name: string }[] = []
 
-      const objectResponse = await request.postgrest
-        .from<Obj>('objects')
-        .select('name')
-        .eq('bucket_id', bucketName)
-        .in('name', paths)
+      for (let i = 0; i < paths.length; ) {
+        const pathsSubset = []
+        let urlParamLength = 0
 
-      if (objectResponse.error) {
-        const { error, status } = objectResponse
-        request.log.error({ error }, 'failed to retrieve object names while getting signed URLs')
-        return response.status(400).send(transformPostgrestError(error, status))
+        for (; i < paths.length && urlParamLength < urlLengthLimit; i++) {
+          const path = paths[i]
+          pathsSubset.push(path)
+          urlParamLength += path.length + 3 // %2C
+        }
+
+        const objectResponse = await request.postgrest
+          .from<Obj>('objects')
+          .select('name')
+          .eq('bucket_id', bucketName)
+          .in('name', pathsSubset)
+
+        if (objectResponse.error) {
+          const { error, status } = objectResponse
+          request.log.error({ error }, 'failed to retrieve object names while getting signed URLs')
+          return response.status(400).send(transformPostgrestError(error, status))
+        }
+
+        const { data } = objectResponse
+        results = results.concat(data)
       }
-
-      const { data: results } = objectResponse
-      request.log.info({ results }, 'results')
 
       const nameSet = new Set(results.map(({ name }) => name))
 

--- a/src/test/db/03-dummy-data.sql.sample
+++ b/src/test/db/03-dummy-data.sql.sample
@@ -37,6 +37,9 @@ INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at
 ('D3EB488E-94F4-46CD-86D3-242C13B95BAC', 'bucket3', 'sadcat-upload2.png', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}'),
 ('746180e8-8029-4134-8a21-48ab35485d81', 'public-bucket', 'favicon.ico', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}');
 ;
+INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at", "updated_at", "last_accessed_at", "metadata")
+SELECT gen_random_uuid(), 'bucket2', 'authenticated/' || i, '317eadce-631a-4429-a0bb-f19a7a517b4a', now(), now(), now(), '{"size": 1234}'
+from generate_series(0, 10000) i;
 
 -- add policies
 -- allows user to CRUD all buckets

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -790,15 +790,16 @@ describe('testing deleting multiple objects', () => {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
       payload: {
-        prefixes: ['authenticated/delete-multiple1.png', 'authenticated/delete-multiple2.png'],
+        prefixes: [...Array(10001).keys()].map((i) => `authenticated/${i}`),
       },
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.deleteObjects).toBeCalled()
 
     const result = JSON.parse(response.body)
-    expect(result[0].name).toBe('authenticated/delete-multiple1.png')
-    expect(result[1].name).toBe('authenticated/delete-multiple2.png')
+    expect(result).toHaveLength(10001)
+    expect(result[0].name).toBe('authenticated/0')
+    expect(result[1].name).toBe('authenticated/1')
   })
 
   test('check if RLS policies are respected: anon user is not able to delete authenticated resource', async () => {
@@ -815,7 +816,7 @@ describe('testing deleting multiple objects', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.deleteObjects).not.toHaveBeenCalled()
     const results = JSON.parse(response.body)
-    expect(results.length).toBe(0)
+    expect(results).toHaveLength(0)
   })
 
   test('user is not able to delete a resource without Auth header', async () => {
@@ -859,7 +860,7 @@ describe('testing deleting multiple objects', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.deleteObjects).not.toHaveBeenCalled()
     const results = JSON.parse(response.body)
-    expect(results.length).toBe(0)
+    expect(results).toHaveLength(0)
   })
 
   test('check if RLS policies are respected: user has permission to delete only one of the objects', async () => {
@@ -876,7 +877,7 @@ describe('testing deleting multiple objects', () => {
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.deleteObjects).toBeCalled()
     const results = JSON.parse(response.body)
-    expect(results.length).toBe(1)
+    expect(results).toHaveLength(1)
     expect(results[0].name).toBe('authenticated/delete-multiple7.png')
   })
 })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,7 @@ type StorageConfigType = {
   serviceKey: string
   storageBackendType: StorageBackendType
   tenantId: string
+  urlLengthLimit: number
   xForwardedHostRegExp?: string
 }
 
@@ -66,6 +67,7 @@ export function getConfig(): StorageConfigType {
       getOptionalConfigFromEnv('PROJECT_REF') ||
       getOptionalIfMultitenantConfigFromEnv('TENANT_ID') ||
       '',
+    urlLengthLimit: Number(getOptionalConfigFromEnv('URL_LENGTH_LIMIT')) || 7_500,
     xForwardedHostRegExp: getOptionalConfigFromEnv('X_FORWARDED_HOST_REGEXP'),
   }
 }


### PR DESCRIPTION
Current URL lengths are unbounded so they can cause 414 URI too long errors when the PostgREST URL is more than ~8K characters, when PostgREST is behind Kong/NGINX, since ~8K is the default limit for Kong/NGINX: http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers.