### PR TITLE
fix: ensure that newly inserted rows are deleted when uploading fails

### DIFF
--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -262,15 +262,15 @@ export default async function routes(fastify: FastifyInstance) {
 
           if (isS3Error(uploadError)) {
             errorName = uploadError.name
-            errorStatusCode = uploadError.$metadata.httpStatusCode ?? 400
+            errorStatusCode = uploadError.$metadata.httpStatusCode ?? 500
             errorMessage = uploadError.message
           } else if (uploadError instanceof Error) {
             errorName = uploadError.name
-            errorStatusCode = 400
+            errorStatusCode = 500
             errorMessage = uploadError.message
           } else {
             errorName = 'Internal service error'
-            errorStatusCode = 400
+            errorStatusCode = 500
           }
 
           // undo operations as super user
@@ -285,7 +285,7 @@ export default async function routes(fastify: FastifyInstance) {
 
           // return an error response
           return response
-            .status(400)
+            .status(errorStatusCode)
             .send(createResponse(errorName, String(errorStatusCode), errorMessage))
         }
       }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,5 @@
+import { S3ServiceException } from '@aws-sdk/client-s3'
+
+export function isS3Error(error: unknown): error is S3ServiceException {
+  return !!error && typeof error === 'object' && '$metadata' in error
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,3 +3,41 @@ import { S3ServiceException } from '@aws-sdk/client-s3'
 export function isS3Error(error: unknown): error is S3ServiceException {
   return !!error && typeof error === 'object' && '$metadata' in error
 }
+
+/**
+ * Converts any errors thrown to a consistent `StorageBackendError` type.
+ */
+export function convertErrorToStorageBackendError(error: unknown) {
+  let name: string
+  let httpStatusCode: number
+  let message: string
+
+  if (isS3Error(error)) {
+    name = error.name
+    httpStatusCode = error.$metadata.httpStatusCode ?? 500
+    message = error.message
+  } else if (error instanceof Error) {
+    name = error.name
+    httpStatusCode = 500
+    message = error.message
+  } else {
+    name = 'Internal service error'
+    httpStatusCode = 500
+    message = 'Internal service error'
+  }
+
+  return new StorageBackendError(name, httpStatusCode, message, error)
+}
+
+export class StorageBackendError extends Error {
+  httpStatusCode: number
+  originalError: unknown
+
+  constructor(name: string, httpStatusCode: number, message: string, originalError?: unknown) {
+    super(message)
+    this.name = name
+    this.httpStatusCode = httpStatusCode
+    this.message = message
+    this.originalError = originalError
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an error occurs while uploading a new file, the associated row in `storage.objects` still exists even though the file might not exist on the storage backend (#125).

## What is the new behavior?

Any errors thrown when uploading a new file will be caught, and associated rows from `storage.objects` table will be removed.