### PR TITLE
chore: temporarily disable route metrics

### DIFF
--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -12,7 +12,7 @@ const build = (opts: FastifyServerOptions = {}, adminOpts: AdminOptions = {}): F
   app.register(tenantRoutes, { prefix: 'tenants' })
   app.register(metrics, {
     endpoint: '/metrics',
-    enableRouteMetrics: true,
+    enableRouteMetrics: false,
     blacklist: ['nodejs_version_info', 'process_start_time_seconds'],
     register: adminOpts.register,
   })


### PR DESCRIPTION
The per-route metrics support for fastifyv3 also collects metrics for
any route encountered by the service, which provides a mechanism for
DoS'ing secondary systems. Disabling these metrics until we upgrade to
v4, where discarding non-registered routes is supported.