### PR TITLE
fix: createObject: return proper "413 Payload too large" status code

### DIFF
--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -204,7 +204,7 @@ export default async function routes(fastify: FastifyInstance) {
 
         // return an error response
         return response
-          .status(400)
+          .status(413)
           .send(
             createResponse(
               'The object exceeded the maximum allowed size',

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -261,14 +261,12 @@ describe('testing POST object via multipart upload', () => {
       headers,
       payload: form,
     })
-    expect(response.statusCode).toBe(400)
-    expect(response.body).toBe(
-      JSON.stringify({
-        statusCode: '413',
-        error: 'Payload too large',
-        message: 'The object exceeded the maximum allowed size',
-      })
-    )
+    expect(response.statusCode).toBe(413)
+    expect(JSON.parse(response.body)).toStrictEqual({
+      statusCode: '413',
+      error: 'Payload too large',
+      message: 'The object exceeded the maximum allowed size',
+    })
   })
 })
 
@@ -422,14 +420,12 @@ describe('testing POST object via binary upload', () => {
       headers,
       payload: fs.createReadStream(path),
     })
-    expect(response.statusCode).toBe(400)
-    expect(response.body).toBe(
-      JSON.stringify({
-        statusCode: '413',
-        error: 'Payload too large',
-        message: 'The object exceeded the maximum allowed size',
-      })
-    )
+    expect(response.statusCode).toBe(413)
+    expect(JSON.parse(response.body)).toStrictEqual({
+      statusCode: '413',
+      error: 'Payload too large',
+      message: 'The object exceeded the maximum allowed size',
+    })
   })
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

HTTP 400 status code is returned even when the response JSON describes the error as status code 413.

## What is the new behavior?

Return HTTP 413 status code.