### PR TITLE
feat: store additional content metadata in storage backends

### DIFF
--- a/src/backend/file.ts
+++ b/src/backend/file.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { promisify } from 'util'
 import stream from 'stream'
 import { getConfig } from '../utils/config'
-import { GenericStorageBackend } from './generic'
+import { GenericStorageBackend, UploadObjectOptions } from './generic'
 import { convertErrorToStorageBackendError } from '../utils/errors'
 const pipeline = promisify(stream.pipeline)
 
@@ -51,13 +51,13 @@ export class FileBackend implements GenericStorageBackend {
     }
   }
 
-  async uploadObject(
-    bucketName: string,
-    key: string,
-    body: NodeJS.ReadableStream,
-    contentType: string,
-    cacheControl: string
-  ): Promise<ObjectMetadata> {
+  async uploadObject({
+    bucketName,
+    key,
+    body,
+    contentType,
+    cacheControl,
+  }: UploadObjectOptions): Promise<ObjectMetadata> {
     try {
       const file = path.resolve(this.filePath, `${bucketName}/${key}`)
       await fs.ensureFile(file)
@@ -70,7 +70,7 @@ export class FileBackend implements GenericStorageBackend {
       return {
         httpStatusCode: 200,
       }
-    } catch (err: any) {
+    } catch (err) {
       throw convertErrorToStorageBackendError(err)
     }
   }

--- a/src/backend/generic.ts
+++ b/src/backend/generic.ts
@@ -12,6 +12,9 @@ export interface UploadObjectOptions {
   body: NodeJS.ReadableStream
   contentType: string
   cacheControl: string
+  contentDisposition?: string
+  contentEncoding?: string
+  contentLanguage?: string
 }
 
 export abstract class GenericStorageBackend {

--- a/src/backend/generic.ts
+++ b/src/backend/generic.ts
@@ -6,6 +6,14 @@ export interface GetObjectHeaders {
   range?: string
 }
 
+export interface UploadObjectOptions {
+  bucketName: string
+  key: string
+  body: NodeJS.ReadableStream
+  contentType: string
+  cacheControl: string
+}
+
 export abstract class GenericStorageBackend {
   client: any
   constructor() {
@@ -18,13 +26,7 @@ export abstract class GenericStorageBackend {
   ): Promise<ObjectResponse> {
     throw new Error('getObject not implemented')
   }
-  async uploadObject(
-    bucketName: string,
-    key: string,
-    body: NodeJS.ReadableStream,
-    contentType: string,
-    cacheControl: string
-  ): Promise<ObjectMetadata> {
+  async uploadObject(options: UploadObjectOptions): Promise<ObjectMetadata> {
     throw new Error('uploadObject not implemented')
   }
   async deleteObject(bucket: string, key: string): Promise<ObjectMetadata> {

--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -61,6 +61,9 @@ export class S3Backend implements GenericStorageBackend {
         lastModified: data.LastModified,
         contentRange: data.ContentRange,
         contentLength: data.ContentLength,
+        contentDisposition: data.ContentDisposition,
+        contentEncoding: data.ContentEncoding,
+        contentLanguage: data.ContentLanguage,
         httpStatusCode: data.$metadata.httpStatusCode,
       },
       body: data.Body,
@@ -73,6 +76,9 @@ export class S3Backend implements GenericStorageBackend {
     body,
     contentType,
     cacheControl,
+    contentDisposition,
+    contentEncoding,
+    contentLanguage,
   }: UploadObjectOptions): Promise<ObjectMetadata> {
     try {
       const paralellUploadS3 = new Upload({
@@ -84,6 +90,9 @@ export class S3Backend implements GenericStorageBackend {
           Body: body,
           ContentType: contentType,
           CacheControl: cacheControl,
+          ContentDisposition: contentDisposition,
+          ContentEncoding: contentEncoding,
+          ContentLanguage: contentLanguage,
         },
       })
 

--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -12,7 +12,7 @@ import https from 'https'
 import { Upload } from '@aws-sdk/lib-storage'
 import { NodeHttpHandler } from '@aws-sdk/node-http-handler'
 import { ObjectMetadata, ObjectResponse } from '../types/types'
-import { GenericStorageBackend, GetObjectHeaders } from './generic'
+import { GenericStorageBackend, GetObjectHeaders, UploadObjectOptions } from './generic'
 import { convertErrorToStorageBackendError } from '../utils/errors'
 
 export class S3Backend implements GenericStorageBackend {
@@ -67,13 +67,13 @@ export class S3Backend implements GenericStorageBackend {
     }
   }
 
-  async uploadObject(
-    bucketName: string,
-    key: string,
-    body: NodeJS.ReadableStream,
-    contentType: string,
-    cacheControl: string
-  ): Promise<ObjectMetadata> {
+  async uploadObject({
+    bucketName,
+    key,
+    body,
+    contentType,
+    cacheControl,
+  }: UploadObjectOptions): Promise<ObjectMetadata> {
     try {
       const paralellUploadS3 = new Upload({
         client: this.client,
@@ -91,7 +91,7 @@ export class S3Backend implements GenericStorageBackend {
       return {
         httpStatusCode: data.$metadata.httpStatusCode,
       }
-    } catch (err: any) {
+    } catch (err) {
       throw convertErrorToStorageBackendError(err)
     }
   }

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -167,13 +167,13 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl = cacheTime ? `max-age=${cacheTime}` : 'no-cache'
         mimeType = data.mimetype
         try {
-          uploadResult = await storageBackend.uploadObject(
-            globalS3Bucket,
-            s3Key,
-            data.file,
-            mimeType,
-            cacheControl
-          )
+          uploadResult = await storageBackend.uploadObject({
+            bucketName: globalS3Bucket,
+            key: s3Key,
+            body: data.file,
+            contentType: mimeType,
+            cacheControl,
+          })
           // since we are using streams, fastify can't throw the error reliably
           // busboy sets the truncated property on streams if limit was exceeded
           // https://github.com/fastify/fastify-multipart/issues/196#issuecomment-782847791
@@ -187,13 +187,13 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl = request.headers['cache-control'] ?? 'no-cache'
 
         try {
-          uploadResult = await storageBackend.uploadObject(
-            globalS3Bucket,
-            s3Key,
-            request.raw,
-            mimeType,
-            cacheControl
-          )
+          uploadResult = await storageBackend.uploadObject({
+            bucketName: globalS3Bucket,
+            key: s3Key,
+            body: request.raw,
+            contentType: mimeType,
+            cacheControl,
+          })
           // @todo more secure to get this from the stream or from s3 in the next step
           isTruncated = Number(request.headers['content-length']) > fileSizeLimit
         } catch (err) {

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -48,7 +48,10 @@ interface createObjectRequestInterface extends RequestGenericInterface {
   Headers: {
     authorization: string
     'content-type': string
+    'content-encoding'?: string
+    'content-language'?: string
     'cache-control'?: string
+    'x-content-disposition'?: string
     'x-upsert'?: string
   }
 }
@@ -84,6 +87,9 @@ export default async function routes(fastify: FastifyInstance) {
       const path = `${bucketName}/${objectName}`
       const s3Key = `${request.tenantId}/${path}`
       let mimeType: string, cacheControl: string
+      let contentDisposition: string | undefined,
+        contentEncoding: string | undefined,
+        contentLanguage: string | undefined
       let isTruncated = false
       let uploadResult: ObjectMetadata
 
@@ -160,12 +166,18 @@ export default async function routes(fastify: FastifyInstance) {
       if (contentType?.startsWith('multipart/form-data')) {
         const data = await request.file({ limits: { fileSize: fileSizeLimit } })
 
+        mimeType = data.mimetype
         // Can't seem to get the typing to work properly
-        // https://github.com/fastify/fastify-multipart/issues/162
-        /* @ts-expect-error: https://github.com/aws/aws-sdk-js-v3/issues/2085 */
+        /* @ts-expect-error: https://github.com/fastify/fastify-multipart/issues/162 */
         const cacheTime = data.fields.cacheControl?.value
         cacheControl = cacheTime ? `max-age=${cacheTime}` : 'no-cache'
-        mimeType = data.mimetype
+        /* @ts-expect-error: https://github.com/fastify/fastify-multipart/issues/162 */
+        contentDisposition = data.fields.contentDisposition?.value
+        /* @ts-expect-error: https://github.com/fastify/fastify-multipart/issues/162 */
+        contentEncoding = data.fields.contentEncoding?.value
+        /* @ts-expect-error: https://github.com/fastify/fastify-multipart/issues/162 */
+        contentLanguage = data.fields.contentLanguage?.value
+
         try {
           uploadResult = await storageBackend.uploadObject({
             bucketName: globalS3Bucket,
@@ -173,6 +185,9 @@ export default async function routes(fastify: FastifyInstance) {
             body: data.file,
             contentType: mimeType,
             cacheControl,
+            contentDisposition,
+            contentEncoding,
+            contentLanguage,
           })
           // since we are using streams, fastify can't throw the error reliably
           // busboy sets the truncated property on streams if limit was exceeded
@@ -185,6 +200,9 @@ export default async function routes(fastify: FastifyInstance) {
         // just assume its a binary file
         mimeType = request.headers['content-type']
         cacheControl = request.headers['cache-control'] ?? 'no-cache'
+        contentDisposition = request.headers['x-content-disposition']
+        contentEncoding = request.headers['content-encoding']
+        contentLanguage = request.headers['content-language']
 
         try {
           uploadResult = await storageBackend.uploadObject({
@@ -193,6 +211,9 @@ export default async function routes(fastify: FastifyInstance) {
             body: request.raw,
             contentType: mimeType,
             cacheControl,
+            contentDisposition,
+            contentEncoding,
+            contentLanguage,
           })
           // @todo more secure to get this from the stream or from s3 in the next step
           isTruncated = Number(request.headers['content-length']) > fileSizeLimit
@@ -232,6 +253,10 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl,
         size: objectMetadata.size,
       }
+      if (contentDisposition) metadata.contentDisposition = contentDisposition
+      if (contentEncoding) metadata.contentEncoding = contentEncoding
+      if (contentLanguage) metadata.contentLanguage = contentLanguage
+
       const { error: updateError, status: updateStatus } = await request.superUserPostgrest
         .from<Obj>('objects')
         .update({

--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -86,6 +86,15 @@ async function requestHandler(
     if (data.metadata.contentRange) {
       response.header('Content-Range', data.metadata.contentRange)
     }
+    if (data.metadata.contentDisposition) {
+      response.header('Content-Disposition', data.metadata.contentDisposition)
+    }
+    if (data.metadata.contentEncoding) {
+      response.header('Content-Encoding', data.metadata.contentEncoding)
+    }
+    if (data.metadata.contentLanguage) {
+      response.header('Content-Language', data.metadata.contentLanguage)
+    }
     return response.send(data.body)
   } catch (err: any) {
     if (err.$metadata?.httpStatusCode === 304) {

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -81,6 +81,15 @@ export default async function routes(fastify: FastifyInstance) {
         if (data.metadata.contentRange) {
           response.header('Content-Range', data.metadata.contentRange)
         }
+        if (data.metadata.contentDisposition) {
+          response.header('Content-Disposition', data.metadata.contentDisposition)
+        }
+        if (data.metadata.contentEncoding) {
+          response.header('Content-Encoding', data.metadata.contentEncoding)
+        }
+        if (data.metadata.contentLanguage) {
+          response.header('Content-Language', data.metadata.contentLanguage)
+        }
         return response.send(data.body)
       } catch (err: any) {
         if (err.$metadata?.httpStatusCode === 304) {

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -87,6 +87,15 @@ export default async function routes(fastify: FastifyInstance) {
         if (data.metadata.contentRange) {
           response.header('Content-Range', data.metadata.contentRange)
         }
+        if (data.metadata.contentDisposition) {
+          response.header('Content-Disposition', data.metadata.contentDisposition)
+        }
+        if (data.metadata.contentEncoding) {
+          response.header('Content-Encoding', data.metadata.contentEncoding)
+        }
+        if (data.metadata.contentLanguage) {
+          response.header('Content-Language', data.metadata.contentLanguage)
+        }
         return response.send(data.body)
       } catch (err: any) {
         if (err.$metadata?.httpStatusCode === 304) {

--- a/src/routes/object/updateObject.ts
+++ b/src/routes/object/updateObject.ts
@@ -120,13 +120,13 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl = cacheTime ? `max-age=${cacheTime}` : 'no-cache'
         mimeType = data.mimetype
 
-        uploadResult = await storageBackend.uploadObject(
-          globalS3Bucket,
-          s3Key,
-          data.file,
-          data.mimetype,
-          cacheControl
-        )
+        uploadResult = await storageBackend.uploadObject({
+          bucketName: globalS3Bucket,
+          key: s3Key,
+          body: data.file,
+          contentType: mimeType,
+          cacheControl,
+        })
 
         // since we are using streams, fastify can't throw the error reliably
         // busboy sets the truncated property on streams if limit was exceeded
@@ -137,13 +137,13 @@ export default async function routes(fastify: FastifyInstance) {
         mimeType = request.headers['content-type']
         cacheControl = request.headers['cache-control'] ?? 'no-cache'
 
-        uploadResult = await storageBackend.uploadObject(
-          globalS3Bucket,
-          s3Key,
-          request.raw,
-          mimeType,
-          cacheControl
-        )
+        uploadResult = await storageBackend.uploadObject({
+          bucketName: globalS3Bucket,
+          key: s3Key,
+          body: request.raw,
+          contentType: mimeType,
+          cacheControl,
+        })
         // @todo more secure to get this from the stream or from s3 in the next step
         isTruncated = Number(request.headers['content-length']) > fileSizeLimit
       }

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -223,6 +223,32 @@ describe('testing public bucket functionality', () => {
       ifNoneMatch: 'abc',
     })
 
+    jest.spyOn(S3Backend.prototype, 'getObject').mockResolvedValue({
+      metadata: {
+        httpStatusCode: 200,
+        size: 0,
+        mimetype: 'image/svg',
+        cacheControl: 'max-age=3600',
+        contentDisposition: 'attachment; filename="favicon.svg"',
+        contentEncoding: 'gzip',
+        contentLanguage: 'en-US',
+      },
+      body: Buffer.from(''),
+    })
+    const customMetadataResponse = await app().inject({
+      method: 'GET',
+      url: `/object/public/public-bucket/favicon.ico`,
+    })
+    expect(customMetadataResponse.statusCode).toBe(200)
+    expect(customMetadataResponse.headers).toMatchObject({
+      'cache-control': 'max-age=3600',
+      'content-length': '0',
+      'content-type': 'image/svg',
+      'content-disposition': 'attachment; filename="favicon.svg"',
+      'content-encoding': 'gzip',
+      'content-language': 'en-US',
+    })
+
     const makePrivateResponse = await app().inject({
       method: 'PUT',
       url: `/bucket/${bucketId}`,

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -43,10 +43,13 @@ type ObjectResponse = {
 type ObjectMetadata = {
   cacheControl?: string
   contentLength?: number
+  contentRange?: string
+  contentDisposition?: string
+  contentEncoding?: string
+  contentLanguage?: string
   size?: number
   mimetype?: string
   lastModified?: Date
   eTag?: string
-  contentRange?: string
   httpStatusCode?: number
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -9,6 +9,8 @@ export type Obj = FromSchema<typeof objectSchema>
 
 export type SignedToken = {
   url: string
+  contentDisposition?: string
+  contentType?: string
 }
 
 export interface AuthenticatedRequest extends RequestGenericInterface {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

When adding/updating objects, only the content type and cache-control values are stored as metadata in the object backend.

## What is the new behavior?

In addition to the content type and cache-control values being stored in the storage backed, the content encoding, content language and content disposition of the uploaded object are also stored in the storage backend. The `metadata` column of the `storage.objects` table is also updated to store these values.

## Additional context

This is supported by both S3 and Google Cloud Storage:
- S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
- GCS: https://cloud.google.com/storage/docs/gsutil/addlhelp/WorkingWithObjectMetadata

This also partially addresses https://github.com/supabase/storage-api/issues/122 by allowing the content disposition to be set when uploading a storage object.