### PR TITLE
feat(signed URLs): allow customizing response headers

### DIFF
--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -2,12 +2,13 @@
 import dotenv from 'dotenv'
 import FormData from 'form-data'
 import fs from 'fs'
+import { URL } from 'url'
 import app from '../app'
 import { getConfig } from '../utils/config'
-import { signJWT } from '../utils/index'
+import { signJWT, verifyJWT } from '../utils/index'
 import { S3Backend } from '../backend/s3'
 import { PostgrestClient } from '@supabase/postgrest-js'
-import { Obj } from '../types/types'
+import { Obj, SignedToken } from '../types/types'
 import { convertErrorToStorageBackendError } from '../utils/errors'
 
 dotenv.config({ path: '.env.test' })
@@ -1315,6 +1316,31 @@ describe('testing generating signed URL', () => {
       },
     })
     expect(response.statusCode).toBe(400)
+  })
+
+  test('should allow setting of custom headers', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/sign/bucket2/public/sadcat-upload.png',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+        responseContentType: 'image/png',
+        responseContentDisposition: 'inline',
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    const result = JSON.parse(response.body)
+    expect(result.signedURL).toBeTruthy()
+    expect(result.signedURL.startsWith('/')).toBe(true)
+    const parsedUrl = new URL(`http://localhost${result.signedURL}`)
+    const tokenString = parsedUrl.searchParams.get('token')
+    expect(tokenString).toBeTruthy()
+    const token = (await verifyJWT(tokenString as string, jwtSecret)) as SignedToken
+    expect(token.contentType).toBe('image/png')
+    expect(token.contentDisposition).toBe('inline')
   })
 })
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -9,6 +9,8 @@ export type Obj = FromSchema<typeof objectSchema>
 
 export type SignedToken = {
   url: string
+  contentDisposition?: string
+  contentType?: string
 }
 
 export interface AuthenticatedRequest extends RequestGenericInterface {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Users are unable to customize the response HTTP headers when creating signed URLs.

## What is the new behavior?

When creating signed URLs, users can customize the response content type and content disposition HTTP headers. 

## Additional context

Both S3 and Google Cloud Storage have this feature:
- S3: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/getobjectcommand.html
  - allows customizing the following headers as well: content-language, expires, cache-control, content-encoding
- GCS:
  - https://cloud.google.com/storage/docs/xml-api/reference-headers#responsecontentdisposition
  - https://cloud.google.com/storage/docs/xml-api/reference-headers#responsecontenttype
  - only allows customizing the response content type and disposition

I've gone with allowing only the response content type and disposition to be customized to go along with the minimum common functionality between these two storage providers.

This addresses https://github.com/supabase/storage-api/issues/122 by allowing the content disposition to be set when requesting a signed URL.

Note: this PR is stacked on #169.