### PR TITLE
add HEAD Mehthod to getObjects route

### DIFF
--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -102,6 +102,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.get<getObjectRequestInterface>(
     '/authenticated/:bucketName/*',
     {
+      exposeHeadRoute: true,
       // @todo add success response schema here
       schema: {
         params: getObjectParamsSchema,
@@ -120,6 +121,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.get<getObjectRequestInterface>(
     '/:bucketName/*',
     {
+      exposeHeadRoute: true,
       // @todo add success response schema here
       schema: {
         params: getObjectParamsSchema,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a `HEAD` Method to `getObject` route so clients can get headers without requesting whole object.

## What is the current behavior?

I get a `400` which is ok but a 405 would be better 😂 

## What is the new behavior?

A `HEAD` request just like the `GET` but without the body (see https://github.com/fastify/fastify/pull/2700/)
