### PR TITLE
fix(jwt): support multi-algorithm of JWT verify

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,7 @@ type StorageConfigType = {
   globalS3Endpoint?: string
   isMultitenant: boolean
   jwtSecret: string
+  jwtAlgorithm: string,
   multitenantDatabaseUrl?: string
   postgrestURL: string
   postgrestURLSuffix?: string
@@ -56,6 +57,7 @@ export function getConfig(): StorageConfigType {
     globalS3Endpoint: getOptionalConfigFromEnv('GLOBAL_S3_ENDPOINT'),
     isMultitenant: getOptionalConfigFromEnv('IS_MULTITENANT') === 'true',
     jwtSecret: getOptionalIfMultitenantConfigFromEnv('PGRST_JWT_SECRET') || '',
+    jwtAlgorithm: getOptionalConfigFromEnv('PGRST_JWT_ALGORITHM') || 'HS256',
     multitenantDatabaseUrl: getOptionalConfigFromEnv('MULTITENANT_DATABASE_URL'),
     postgrestURL: getOptionalIfMultitenantConfigFromEnv('POSTGREST_URL') || '',
     postgrestURLSuffix: getOptionalConfigFromEnv('POSTGREST_URL_SUFFIX'),
@@ -67,7 +69,7 @@ export function getConfig(): StorageConfigType {
       getOptionalConfigFromEnv('PROJECT_REF') ||
       getOptionalIfMultitenantConfigFromEnv('TENANT_ID') ||
       '',
-    urlLengthLimit: Number(getOptionalConfigFromEnv('URL_LENGTH_LIMIT')) || 7_500,
+      urlLengthLimit: Number(getOptionalConfigFromEnv('URL_LENGTH_LIMIT')) || 7_500,
     xForwardedHostRegExp: getOptionalConfigFromEnv('X_FORWARDED_HOST_REGEXP'),
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,7 @@ import {
   getJwtSecret as getJwtSecretForTenant,
 } from './tenant'
 
-const { isMultitenant, jwtSecret } = getConfig()
+const { isMultitenant, jwtSecret, jwtAlgorithm } = getConfig()
 
 interface jwtInterface {
   sub: string
@@ -34,7 +34,7 @@ export function verifyJWT(
   secret: string
 ): Promise<string | jwt.JwtPayload | undefined> {
   return new Promise((resolve, reject) => {
-    jwt.verify(token, secret, (err, decoded) => {
+    jwt.verify(token, secret, { algorithms: [jwtAlgorithm as jwt.Algorithm]}, (err, decoded) => {
       if (err) return reject(err)
       resolve(decoded)
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

- To make supabase storage support multiple JWT verify algorithm (e.g. RS256)
- To support base64 of`PGRST_JWT_SECRET`

## What is the current behavior?

The verifyJWT function does not support RS256 here https://github.com/supabase/storage-api/blob/9bf39cd2b5f897b55b60a4af7cadc8b5f53b33af/src/utils/index.ts#L37

## What is the new behavior?

The verifyJWT function support RS256 and other algorithms.
