### PR TITLE
feat: switch to OpenAPI v3

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   if (opts.exposeDocs) {
     app.register(fastifySwagger, {
       exposeRoute: true,
-      swagger: {
+      openapi: {
         info: {
           title: 'Supabase Storage API',
           description: 'API documentation for Supabase Storage',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Swagger (OpenAPI v2) is used for the documentation.

## What is the new behavior?

OpenAPI v3 is used.