### PR TITLE
fix: exclude token query string from logs

### DIFF
--- a/src/plugins/log-request.ts
+++ b/src/plugins/log-request.ts
@@ -1,4 +1,5 @@
 import fastifyPlugin from 'fastify-plugin'
+import { redactQueryParamFromRequest } from '../monitoring'
 
 interface RequestLoggerOptions {
   excludeUrls?: string[]
@@ -12,7 +13,7 @@ export default (options: RequestLoggerOptions) =>
       }
 
       const rMeth = req.method
-      const rUrl = req.url
+      const rUrl = redactQueryParamFromRequest(req, ['token'])
       const uAgent = req.headers['user-agent']
       const rId = req.id
       const cIP = req.ip


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

Currently we log the entire request url

## What is the new behavior?

We want to exclude the `token` query string parameter from the logs
