### PR TITLE
feat: enable passing extra configurable headers to postgrest client.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM node:18-alpine
 RUN npm install -g pm2
 WORKDIR /app
 COPY migrations migrations
-COPY ecosystem.config.js package.json .
+COPY ecosystem.config.js package.json ./
 COPY --from=0 /app/node_modules node_modules
 COPY --from=1 /app/dist dist
 EXPOSE 5000

--- a/src/test/utils/plugins.test.ts
+++ b/src/test/utils/plugins.test.ts
@@ -1,0 +1,46 @@
+'use strict'
+
+import { generateForwardHeaders } from '../../utils/plugins'
+import { FastifyRequest } from 'fastify'
+
+describe('test generateForwardHeaders function', () => {
+  test('it should return empty object when forwardHeaders is undefined', () => {
+    const request: jest.Mocked<FastifyRequest> = { headers: { test: 'test' } } as any
+    const result = generateForwardHeaders(undefined, request)
+    expect(result).toStrictEqual({})
+  })
+
+  test('it should trim the forward headers and generate produce correct results', () => {
+    const request: jest.Mocked<FastifyRequest> = {
+      headers: {
+        'custom-first-header': 'first',
+        'custom-second-header': 'second',
+      },
+    } as any
+    const result = generateForwardHeaders(' custom-first-header ,   custom-second-header  ', request)
+    expect(result).toStrictEqual({
+      'custom-first-header': 'first',
+      'custom-second-header': 'second',
+    })
+  })
+
+  test('it should ignore specific headers to forward if specified', () => {
+    const request: jest.Mocked<FastifyRequest> = {
+      headers: {
+        'custom-first-header': 'first',
+        'custom-second-header': 'second',
+        'custom-third-header': 'third',
+      },
+    } as any
+    const result = generateForwardHeaders(
+      'custom-first-header,custom-second-header,custom-third-header',
+      request,
+      ['custom-third-header'],
+    )
+    expect(result).toStrictEqual({
+      'custom-first-header': 'first',
+      'custom-second-header': 'second',
+    })
+  })
+
+})

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,6 +27,7 @@ type StorageConfigType = {
   logflareEnabled?: boolean
   logflareApiKey?: string
   logflareSourceToken?: string
+  forwardHeaders?: string
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -79,5 +80,6 @@ export function getConfig(): StorageConfigType {
     logflareEnabled: getOptionalConfigFromEnv('LOGFLARE_ENABLED') === 'true',
     logflareApiKey: getOptionalConfigFromEnv('LOGFLARE_API_KEY'),
     logflareSourceToken: getOptionalConfigFromEnv('LOGFLARE_SOURCE_TOKEN'),
+    forwardHeaders: getOptionalConfigFromEnv('FORWARD_HEADERS')
   }
 }

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -1,0 +1,24 @@
+import { FastifyRequest } from 'fastify'
+
+export function generateForwardHeaders(
+  forwardHeaders: string | undefined,
+  request: FastifyRequest,
+  ignore: string[] = []
+): Record<string, string> {
+  if (!forwardHeaders) {
+    return {}
+  }
+
+  return forwardHeaders.split(',')
+    .map(headerName => headerName.trim())
+    .filter(headerName => headerName in request.headers && !ignore.includes(headerName))
+    .reduce((extraHeaders, headerName) => {
+      const headerValue = request.headers[headerName];
+      if (typeof headerValue !== 'string') {
+        throw new Error(`header ${headerName} must be string`);
+      }
+      extraHeaders[headerName] = headerValue;
+      return extraHeaders;
+    }, <Record<string, string>>{});
+
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
feature

## What is the current behavior?
During creating postgREST client, only `apiKey` and `Authorization` headers are passed in.
https://github.com/supabase/storage-api/issues/190

## What is the new behavior?
Extra headers can be forwarded during creating postgREST client, and they are configurable via a configuration variable.

## Additional context
For more context please refer to [issue](https://github.com/supabase/storage-api/issues/190)
