### PR TITLE
fix: use correct format for last modified date header

### DIFF
--- a/src/routes/object/getObject.ts
+++ b/src/routes/object/getObject.ts
@@ -82,7 +82,7 @@ async function requestHandler(
       .header('Cache-Control', data.metadata.cacheControl)
       .header('ETag', data.metadata.eTag)
       .header('Content-Length', data.metadata.contentLength)
-      .header('Last-Modified', data.metadata.lastModified)
+      .header('Last-Modified', data.metadata.lastModified?.toUTCString())
     if (data.metadata.contentRange) {
       response.header('Content-Range', data.metadata.contentRange)
     }

--- a/src/routes/object/getPublicObject.ts
+++ b/src/routes/object/getPublicObject.ts
@@ -77,7 +77,7 @@ export default async function routes(fastify: FastifyInstance) {
           .header('Cache-Control', data.metadata.cacheControl)
           .header('Content-Length', data.metadata.contentLength)
           .header('ETag', data.metadata.eTag)
-          .header('Last-Modified', data.metadata.lastModified)
+          .header('Last-Modified', data.metadata.lastModified?.toUTCString())
         if (data.metadata.contentRange) {
           response.header('Content-Range', data.metadata.contentRange)
         }

--- a/src/routes/object/getSignedObject.ts
+++ b/src/routes/object/getSignedObject.ts
@@ -83,7 +83,7 @@ export default async function routes(fastify: FastifyInstance) {
           .header('Cache-Control', data.metadata.cacheControl)
           .header('Content-Length', data.metadata.contentLength)
           .header('ETag', data.metadata.eTag)
-          .header('Last-Modified', data.metadata.lastModified)
+          .header('Last-Modified', data.metadata.lastModified?.toUTCString())
         if (data.metadata.contentRange) {
           response.header('Content-Range', data.metadata.contentRange)
         }

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -18,6 +18,8 @@ beforeAll(() => {
         httpStatusCode: 200,
         size: 3746,
         mimetype: 'image/png',
+        lastModified: new Date('Thu, 12 Aug 2021 16:00:00 GMT'),
+        eTag: 'abc',
       },
       body: Buffer.from(''),
     })
@@ -202,6 +204,8 @@ describe('testing public bucket functionality', () => {
       url: `/object/public/public-bucket/favicon.ico`,
     })
     expect(publicResponse.statusCode).toBe(200)
+    expect(publicResponse.headers['etag']).toBe('abc')
+    expect(publicResponse.headers['last-modified']).toBe('Thu, 12 Aug 2021 16:00:00 GMT')
 
     const mockGetObject = jest.spyOn(S3Backend.prototype, 'getObject')
     mockGetObject.mockRejectedValue({
@@ -213,13 +217,13 @@ describe('testing public bucket functionality', () => {
       method: 'GET',
       url: `/object/public/public-bucket/favicon.ico`,
       headers: {
-        'if-modified-since': 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+        'if-modified-since': 'Thu, 12 Aug 2021 16:00:00 GMT',
         'if-none-match': 'abc',
       },
     })
     expect(notModifiedResponse.statusCode).toBe(304)
     expect(mockGetObject.mock.calls[1][2]).toMatchObject({
-      ifModifiedSince: 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+      ifModifiedSince: 'Thu, 12 Aug 2021 16:00:00 GMT',
       ifNoneMatch: 'abc',
     })
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -32,6 +32,8 @@ beforeEach(() => {
       httpStatusCode: 200,
       size: 3746,
       mimetype: 'image/png',
+      lastModified: new Date('Thu, 12 Aug 2021 16:00:00 GMT'),
+      eTag: 'abc',
     },
     body: Buffer.from(''),
   })
@@ -76,6 +78,8 @@ describe('testing GET object', () => {
       },
     })
     expect(response.statusCode).toBe(200)
+    expect(response.headers['etag']).toBe('abc')
+    expect(response.headers['last-modified']).toBe('Thu, 12 Aug 2021 16:00:00 GMT')
     expect(S3Backend.prototype.getObject).toBeCalled()
   })
 
@@ -91,13 +95,13 @@ describe('testing GET object', () => {
       url: '/object/authenticated/bucket2/authenticated/casestudy.png',
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
-        'if-modified-since': 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+        'if-modified-since': 'Thu, 12 Aug 2021 16:00:00 GMT',
         'if-none-match': 'abc',
       },
     })
     expect(response.statusCode).toBe(304)
     expect(mockGetObject.mock.calls[0][2]).toMatchObject({
-      ifModifiedSince: 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+      ifModifiedSince: 'Thu, 12 Aug 2021 16:00:00 GMT',
       ifNoneMatch: 'abc',
     })
   })
@@ -1214,6 +1218,8 @@ describe('testing retrieving signed URL', () => {
       url: `/object/sign/${urlToSign}?token=${jwtToken}`,
     })
     expect(response.statusCode).toBe(200)
+    expect(response.headers['etag']).toBe('abc')
+    expect(response.headers['last-modified']).toBe('Thu, 12 Aug 2021 16:00:00 GMT')
   })
 
   test('forward 304 and If-Modified-Since/If-None-Match headers', async () => {
@@ -1229,13 +1235,13 @@ describe('testing retrieving signed URL', () => {
       method: 'GET',
       url: `/object/sign/${urlToSign}?token=${jwtToken}`,
       headers: {
-        'if-modified-since': 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+        'if-modified-since': 'Thu, 12 Aug 2021 16:00:00 GMT',
         'if-none-match': 'abc',
       },
     })
     expect(response.statusCode).toBe(304)
     expect(mockGetObject.mock.calls[0][2]).toMatchObject({
-      ifModifiedSince: 'Fri Aug 13 2021 00:00:00 GMT+0800 (Singapore Standard Time)',
+      ifModifiedSince: 'Thu, 12 Aug 2021 16:00:00 GMT',
       ifNoneMatch: 'abc',
     })
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix

## What is the current behavior?

Browser (or other client) never cache the images from storage: https://github.com/supabase/storage-api/issues/193

## What is the new behavior?

When setting the `last-modified` header, use `toUTCString` to ensure the date format adheres to [the rfc2616 spec](https://datatracker.ietf.org/doc/html/rfc2616#section-3.3.1)

## Additional context

- I learned that all of these response headers are not yet tested (eg all tests are passing even after I removed all of these lines). This PR mocks the request headers and asserts the response headers
https://github.com/supabase/storage-api/blob/6e2ae7a521db22af37f8d612cdfab6ad00ca4c9f/src/routes/object/getObject.ts#L81-L85

- For running the tests multiple times, it seemed that we can't run them without restarting the whole container. Running jest twice failed for me because I think there is no resets between tests. I ended up running the tests one-by-one as I am only interested on the `GET` requests, so running them multiple times is fine as it doesn't change the db.

- The fix might be premature as I haven't actually confirmed the bug yet. Please check and respond to the [filed issue](https://github.com/supabase/storage-api/issues/193). Happy to close the PR if turns out that it's not an actual bug, happy to be corrected or improved if the bug is valid 👍 