### PR TITLE
feat: force downloading file when providing filename

### DIFF
--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -102,6 +102,38 @@ describe('testing GET object', () => {
     })
   })
 
+  test('force downloading file with default name', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/object/authenticated/bucket2/authenticated/casestudy.png?download',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(S3Backend.prototype.getObject).toBeCalled()
+    expect(response.headers).toEqual(
+      expect.objectContaining({
+        'content-disposition': `attachment;`,
+      })
+    )
+  })
+
+  test('force downloading file with a custom name', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/object/authenticated/bucket2/authenticated/casestudy.png?download=testname.png',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+    expect(S3Backend.prototype.getObject).toBeCalled()
+    expect(response.headers).toEqual(
+      expect.objectContaining({
+        'content-disposition': `attachment; filename=testname.png; filename*=UTF-8''testname.png;`,
+      })
+    )
+  })
+
   test('check if RLS policies are respected: anon user is not able to read authenticated resource', async () => {
     const response = await app().inject({
       method: 'GET',


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

we can only rely on HTML tags to download a file

## What is the new behavior?

Adds a new query string parameter `filename` which if provided the file will be forced to be downloaded by the browser
by adding the content-disposition header

## Additional context

Closes https://github.com/supabase/storage-api/issues/122
