### PR TITLE
feat: return object id on object operations

### DIFF
--- a/src/routes/object/copyObject.ts
+++ b/src/routes/object/copyObject.ts
@@ -29,9 +29,13 @@ const copyRequestBodySchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    Id: {
+      type: 'string',
+      examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'],
+    },
     Key: { type: 'string', examples: ['folder/destination.png'] },
   },
-  required: ['Key'],
+  required: ['Key', 'Id'],
 }
 interface copyRequestInterface extends AuthenticatedRequest {
   Body: FromSchema<typeof copyRequestBodySchema>
@@ -109,12 +113,7 @@ export default async function routes(fastify: FastifyInstance) {
         data: results,
         error,
         status,
-      } = await request.postgrest
-        .from<Obj>('objects')
-        .insert([newObject], {
-          returning: 'minimal',
-        })
-        .single()
+      } = await request.postgrest.from<Obj>('objects').insert(newObject).single()
 
       if (error) {
         request.log.error({ error }, 'error object')
@@ -130,6 +129,7 @@ export default async function routes(fastify: FastifyInstance) {
         s3DestinationKey
       )
       return response.status(copyResult.httpStatusCode ?? 200).send({
+        Id: results?.id,
         Key: `${bucketId}/${destinationKey}`,
       })
     }

--- a/src/routes/object/createObject.ts
+++ b/src/routes/object/createObject.ts
@@ -36,12 +36,16 @@ const createObjectParamsSchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    Id: {
+      type: 'string',
+      examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'],
+    },
     Key: {
       type: 'string',
       examples: ['avatars/folder/cat.png'],
     },
   },
-  required: ['Key'],
+  required: ['Id', 'Key'],
 }
 interface createObjectRequestInterface extends RequestGenericInterface {
   Params: FromSchema<typeof createObjectParamsSchema>
@@ -232,7 +236,11 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl,
         size: objectMetadata.size,
       }
-      const { error: updateError, status: updateStatus } = await request.superUserPostgrest
+      const {
+        error: updateError,
+        status: updateStatus,
+        data: updateStatusData,
+      } = await request.superUserPostgrest
         .from<Obj>('objects')
         .update({
           metadata,
@@ -246,6 +254,7 @@ export default async function routes(fastify: FastifyInstance) {
       }
 
       return response.status(uploadResult.httpStatusCode ?? 200).send({
+        Id: updateStatusData?.id,
         Key: path,
       })
 

--- a/src/routes/object/updateObject.ts
+++ b/src/routes/object/updateObject.ts
@@ -34,9 +34,13 @@ const updateObjectParamsSchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    Id: {
+      type: 'string',
+      examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'],
+    },
     Key: { type: 'string', examples: ['projectref/avatars/folder/cat.png'] },
   },
-  required: ['Key'],
+  required: ['Id', 'Key'],
 }
 interface updateObjectRequestInterface extends RequestGenericInterface {
   Params: FromSchema<typeof updateObjectParamsSchema>
@@ -159,7 +163,11 @@ export default async function routes(fastify: FastifyInstance) {
         cacheControl,
         size: objectMetadata.size,
       }
-      const { error: updateError, status: updateStatus } = await request.postgrest
+      const {
+        error: updateError,
+        status: updateStatus,
+        data: updateStatusData,
+      } = await request.postgrest
         .from<Obj>('objects')
         .update({
           metadata,
@@ -173,6 +181,7 @@ export default async function routes(fastify: FastifyInstance) {
       }
 
       return response.status(uploadResult.httpStatusCode ?? 200).send({
+        Id: updateStatusData?.id,
         Key: path,
       })
     }

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -200,7 +200,10 @@ describe('testing POST object via multipart upload', () => {
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.uploadObject).toBeCalled()
-    expect(response.body).toBe(`{"Key":"bucket2/authenticated/casestudy1.png"}`)
+    expect(response.json()).toMatchObject({
+      Key: 'bucket2/authenticated/casestudy1.png',
+      Id: expect.any(String),
+    })
   })
 
   test('check if RLS policies are respected: anon user is not able to upload authenticated resource', async () => {
@@ -408,7 +411,10 @@ describe('testing POST object via binary upload', () => {
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.uploadObject).toBeCalled()
-    expect(response.body).toBe(`{"Key":"bucket2/authenticated/binary-casestudy1.png"}`)
+    expect(response.json()).toMatchObject({
+      Id: expect.any(String),
+      Key: 'bucket2/authenticated/binary-casestudy1.png',
+    })
   })
 
   test('check if RLS policies are respected: anon user is not able to upload authenticated resource', async () => {
@@ -640,7 +646,10 @@ describe('testing PUT object', () => {
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.uploadObject).toBeCalled()
-    expect(response.body).toBe(`{"Key":"bucket2/authenticated/cat.jpg"}`)
+    expect(response.json()).toMatchObject({
+      Id: expect.any(String),
+      Key: 'bucket2/authenticated/cat.jpg',
+    })
   })
 
   test('check if RLS policies are respected: anon user is not able to update authenticated resource', async () => {
@@ -733,7 +742,10 @@ describe('testing PUT object via binary upload', () => {
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.uploadObject).toBeCalled()
-    expect(response.body).toBe(`{"Key":"bucket2/authenticated/cat.jpg"}`)
+    expect(response.json()).toMatchObject({
+      Id: expect.any(String),
+      Key: 'bucket2/authenticated/cat.jpg',
+    })
   })
 
   test('check if RLS policies are respected: anon user is not able to update authenticated resource', async () => {
@@ -835,7 +847,10 @@ describe('testing copy object', () => {
     })
     expect(response.statusCode).toBe(200)
     expect(S3Backend.prototype.copyObject).toBeCalled()
-    expect(response.body).toBe(`{"Key":"bucket2/authenticated/casestudy11.png"}`)
+    expect(response.json()).toMatchObject({
+      Id: expect.any(String),
+      Key: 'bucket2/authenticated/casestudy11.png',
+    })
   })
 
   test('check if RLS policies are respected: anon user is not able to update authenticated resource', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

currently is not possible to create relationships from the client side to an object because the id is never returned

## What is the new behavior?

object id is returned on the following operations:

- `createObject`
- `copyObject`
- `updateObject`
