### PR TITLE
feat: image resizing with imgproxy backend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,3 +22,5 @@ ENCRYPTION_KEY=encryptionkey
 LOGFLARE_ENABLED=false
 LOGFLARE_API_KEY=api_key
 LOGFLARE_SOURCE_TOKEN=source_token
+
+IMGPROXY_URL=http://localhost:50020

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Tests pass
         run: |
+          mkdir data && chmod -R 777 data && \
           npm run test:coverage
         env:
           ANON_KEY: ${{ secrets.ANON_KEY }}
@@ -66,6 +67,7 @@ jobs:
           MULTITENANT_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5433/postgres
           POSTGREST_URL_SUFFIX: /rest/v1
           ADMIN_API_KEYS: apikey
+          IMGPROXY_URL: http://127.0.0.1:50020
 
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@master

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.9.3",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.53.0",
-        "@aws-sdk/lib-storage": "^3.53.0",
-        "@aws-sdk/node-http-handler": "^3.53.0",
+        "@aws-sdk/client-s3": "^3.181.0",
+        "@aws-sdk/lib-storage": "^3.182.0",
+        "@aws-sdk/node-http-handler": "^3.178.0",
+        "@aws-sdk/s3-request-presigner": "^3.182.0",
         "@fastify/multipart": "^7.1.0",
         "@fastify/swagger": "^7.4.1",
         "@supabase/postgrest-js": "^0.36.0",
+        "axios": "^0.27.2",
         "crypto-js": "^4.1.1",
         "dotenv": "^16.0.0",
         "fastify": "^4.2.1",
@@ -184,11 +186,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -199,448 +201,449 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
-      "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.178.0.tgz",
+      "integrity": "sha512-ptDkCB06BJrYdhKzamM9yI15LxcGkPczY80hzKAY/aecm09alnW27uCt5HJJx2nCd18IUH28ZO1sc7DTLOWb3A==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
-      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.170.0.tgz",
+      "integrity": "sha512-73Fy1u9zR9ZMC59QobuCWg3LoYfcrFsrP8569vvqtlGqPuQUW+RW3gfx0omIDmxaSg8qq8REPLJFrAGfeL7VtQ==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
-      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.170.0.tgz",
+      "integrity": "sha512-haJ7fdWaOgAM4trw2LBd1VIvRFzMMPz2jy9mu4rE+z1uHbPZHNMGytBo1FJO2DShzUCmJZi3t3CD/7aE3H38+w==",
       "dependencies": {
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.53.0.tgz",
-      "integrity": "sha512-2RSGn8ggS1Uu2f/n1IAhPNShlXMoof2uyjr/N236uVvyQHwxmsG/yJCc/lYJHSZyIBlYhqBiQ0DGGV2QuwzS8A==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.181.0.tgz",
+      "integrity": "sha512-EUJ/Y8SWALh5bfxcg+LQytpI/R3KXHYilWRnBBsKLBUfAWPj+8NzZdDK8wD/6htBtAV4XnqHux3cMCnpeoRf8g==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.53.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-node": "3.53.0",
-        "@aws-sdk/eventstream-serde-browser": "3.53.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.53.0",
-        "@aws-sdk/eventstream-serde-node": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-blob-browser": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/hash-stream-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/md5-js": "3.53.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-expect-continue": "3.53.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-location-constraint": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-sdk-s3": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/middleware-ssec": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-stream-browser": "3.53.0",
-        "@aws-sdk/util-stream-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.53.0",
-        "@aws-sdk/xml-builder": "3.52.0",
+        "@aws-sdk/client-sts": "3.181.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/eventstream-serde-browser": "3.178.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.178.0",
+        "@aws-sdk/eventstream-serde-node": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-blob-browser": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/hash-stream-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/md5-js": "3.178.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-expect-continue": "3.178.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-location-constraint": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-s3": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-ssec": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4-multi-region": "3.180.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-stream-browser": "3.178.0",
+        "@aws-sdk/util-stream-node": "3.178.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "@aws-sdk/util-waiter": "3.180.0",
+        "@aws-sdk/xml-builder": "3.170.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
-      "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.181.0.tgz",
+      "integrity": "sha512-p/HsYVAO7fgjFfn4LqlnlpSKPXGPegAwjPpY+SqyK3/Hj1OtED4whG8LTgxZSTtYwNIkHEjrHnXTiymyXh34Aw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
-      "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.181.0.tgz",
+      "integrity": "sha512-j//F9kjdSv9lUa8p87cg+xk6l5E8o8+GTYP5838eFQR7XcEc3yEljSCkuj2xIzrtf1jKuMXBnswTKmxJhjbTzQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-node": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-sdk-sts": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-sts": "3.179.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
-      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.178.0.tgz",
+      "integrity": "sha512-8xL98TGMaVULIN7HRWV2q1o0Y2p38QuweehzM8yXCZrrLOyHgWo3waP2RNVeddOB7MrSwwU/gw9rXSv7YHLZ6w==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
-      "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.178.0.tgz",
+      "integrity": "sha512-5CMswTJ188RuK9TmI5yAosIsyu4Mm9Cdq1068tRls5EqqwGK1PI7Q007b6rD7zqCb5IgeFBV0t2DxHkBmHRd3w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
-      "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.178.0.tgz",
+      "integrity": "sha512-ZvqQTi3+S13LACVgaWNCOKBv5jROIz7rqyZh56QunAkaAUqPbpM4VFODgAGZYPCOSggZbEUUqXOVB9xSnshLnA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
-      "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.181.0.tgz",
+      "integrity": "sha512-jOa42qYFgkdMumw0IRO0ASAjM0vZMXvPpy3DGOaG0Ehy4KHeykEj4/J23SxCTCkOqAbz2+8XVCuyTExUmWCuWw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/credential-provider-sso": "3.53.0",
-        "@aws-sdk/credential-provider-web-identity": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
-      "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.181.0.tgz",
+      "integrity": "sha512-RlLdp+7faCKzJsmUlBSr4CjqN9WG+YZpmuVVlW5fXGUdXLBLEvLMTl5rmwKtRSUytyYK0Vqtmt48I4nBze8MrA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/credential-provider-ini": "3.53.0",
-        "@aws-sdk/credential-provider-process": "3.53.0",
-        "@aws-sdk/credential-provider-sso": "3.53.0",
-        "@aws-sdk/credential-provider-web-identity": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-ini": "3.181.0",
+        "@aws-sdk/credential-provider-process": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
-      "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.178.0.tgz",
+      "integrity": "sha512-J4TldKrAnfayvRfxNEnLJUnTgkpTcct6rc7PwZlVSGSUgjglbcqfemUOP/pisLKbVNNL742lsUXmkUVH4km0Fw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
-      "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.181.0.tgz",
+      "integrity": "sha512-03YAvns+P7hw5rLwYLExezn9iGX9HD2GAKCEgpSaZSlNLzMw0jU7VEmqJvrLqi+xAoshuRR5A3v8HFQU246QRA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sso": "3.181.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
-      "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.178.0.tgz",
+      "integrity": "sha512-aei8o9ALtzwgYsZCAWdr+ItJyYTkYRmCoKstM4mkGtWNK9BjdISaVUAnndl6Pc/l/5eiK+2rlA+6Ujs4H8m+XQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-marshaller": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.53.0.tgz",
-      "integrity": "sha512-Vt8OjC0hgF0rNcGPbMEROnM5SHODzRdQsG9Y+M2suWDkUqFoh8+6m4v9c/ej3iudAEydZDLcnpV9yGv/CTqceg==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.178.0.tgz",
+      "integrity": "sha512-x18waxfidmI9i4BLpnwV37rxHPyyviyWo5qRgYWX+gLxhN6Z6sB3/Pc/s8/yQmywMs6/DlMBYJUDTvYXR1cezA==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.53.0.tgz",
-      "integrity": "sha512-B+nAlXet/NSEIzaN4fZYGwoFHBYtURuXUE+Ru4EaWyC8+vBEdeO4Vs9o/8mlZSHGiUn41QYYqiZvd+OKweTtBA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.178.0.tgz",
+      "integrity": "sha512-UMlCevpJoQ8oMlNKlQF0Ti5zIztLzx9zcrxfi4KK1A22qXamTA5kHloyq1mFwrTkbcr4uhQ9omDDx//hYQ+yNw==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/eventstream-serde-universal": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.53.0.tgz",
-      "integrity": "sha512-4O66c1aSgfdWfbr2pUJTONReVwA4oWQ/fRMhcAMhacqbPko5+3v0Iy/vOiVCm6Isa4K2kVpOUN0L+64niE7jag==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.178.0.tgz",
+      "integrity": "sha512-LmH5JuNCOvUI2g/7e2qlvHqRQW316J5iTawZQd233xUlmRO49kHc8HFvKPo98/V/S4MFsjlrZF9dcnly2txCxw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.53.0.tgz",
-      "integrity": "sha512-92rlY8M8+nU4mUm3j4gtJiv9HY2fGTGLSIGLukOXAUf7xuJ220L+9ZInS4ToiRgq+dOSt8cFPCxRVpQtNesBfA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.178.0.tgz",
+      "integrity": "sha512-YsFoZ8MlVReGm7GKMjvo5vxLVo/ZPSDg6ckp7kff18zZMlbNtuK+zfgub3tX1f2hbDoV2bBVL3xuZJkeBELpHQ==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/eventstream-serde-universal": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.53.0.tgz",
-      "integrity": "sha512-Y3OjTAKhDyz2UyLE0ATmDD3RFyBfJLWeBQkpJu7qICI0XYN2tmV1mCkQUtkT3e4s+UxnuUOa55YQpdUsQUWIDA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.178.0.tgz",
+      "integrity": "sha512-Rd8QjqzN2roSHsLn0y1iCt/KrEQL2qlNdunXRjBwXvjZGuODa6M8gpOvaPNpTWLiD+V6mO0zuPp+tWiLZxMndw==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-codec": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
-      "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.178.0.tgz",
+      "integrity": "sha512-T/LCNwCihdVNzGn39Dw7tk2U1fMlupFlCsAvDBbO+FOM3h+y9WLHzxmlAVsjPrFXlzdONKf9zd5cuQ+ZW93yAQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/querystring-builder": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.53.0.tgz",
-      "integrity": "sha512-A3xa0o1W9/tALw0/yoXyBKfxsMlzi1BvzEgCFUU2y914yBo62FiIf1E+BX42m9MfPJ87SD+l3O5QcptMVWvarw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.178.0.tgz",
+      "integrity": "sha512-LgrKDNi56q3ayxcvbC0MMt/fgliKgMb8G2o1y6bUAKzlEtBHLFfTUjvzW1WsDfK8ZSrtz/bZNGECIjeFEdTggQ==",
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.52.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/chunked-blob-reader": "3.170.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
-      "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.178.0.tgz",
+      "integrity": "sha512-mqYraRQlvPO5egUKTNZ1kP52sfwBlsz7woOewQTHOGomZBDXrh8bl1J+sgaDi1NAwXdZUgxuD3QKxxAKRs9a2Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.53.0.tgz",
-      "integrity": "sha512-AggSL/LQ/B1T9Ho+EVKlTmuSe/hE74KFNCQWXJUF21zYVZY7ssUd67lEpzCWkhNgcCqt8TE5uE7S0scPA/vDxw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.178.0.tgz",
+      "integrity": "sha512-YzockpOajp5WOweB+/hIrQy9KNVXEgnbMDcuCmevYfoub+BJbjCs5eAZrhCJBkXpRKBz3X1U0vlYp7twFacPqw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
-      "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.178.0.tgz",
+      "integrity": "sha512-JJNaiLr3nbRYym6oUAAaoFFYtDnIZ9Scco2p4sG/thT2eyAfXcEdNl1cSD3E/R1J+Ml/YplqTiIY4u1KPAriRw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
+      "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.53.0.tgz",
-      "integrity": "sha512-fXhpbkC0tZAQat9xE73XjYBiw5gmrcJ/0ctkeSJtGsXsvwxalw0esk7i1paNsL2zoWNoib1M/vUNTcsKGW725A==",
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.182.0.tgz",
+      "integrity": "sha512-12MleBxo9f74R1x4rvVYEkyJyUtp+YNbpCSR+8v7VuBJm0LVugCbKRasle+xmWsWI/Pd20OXalzManWZIWMQDA==",
       "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.182.0",
+        "@aws-sdk/smithy-client": "3.180.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -651,133 +654,151 @@
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
-      "integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.178.0.tgz",
+      "integrity": "sha512-o/F4QKjJL2gQdGq5eQnVGc9SlJ+/TjUBDJfn0Nyz4/OhDYVRvf4yJLT3+I9ZQN5M6DoFgqrLPH0MUHv4EmDPpw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.53.0.tgz",
-      "integrity": "sha512-q88eevXUkUWp6e/vHGnpt8/8TjscbfW6CWGpexj3DFWt3WZhEhExcoGwwszoL4FQfMFWBL+11EKNZm2orHqDwg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.178.0.tgz",
+      "integrity": "sha512-HCHonBmv5SWZMZqVNtWr73d6moZfcqTI87Xmi0Ofpra8tmu99WQpYgXmVLqK13wlPP2MJErBLkcDt15dsS0pJw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
-      "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.178.0.tgz",
+      "integrity": "sha512-p3n3IzU03eRzZivEoQn1HA83LbAKukZwRevsJpya1UfCUtWkXQO3v0jU8rhZE4deGa9k7zuCAEmJ8nCw3QxclQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.182.0.tgz",
+      "integrity": "sha512-F51nTuxdZ0oTuqU2+Ca+l/Ysvn6ukLyujvHhyJfolquKX+ra/CBEC/Unhksl7ORolehm+iwbryyO7MHq7BWGkA==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.53.0.tgz",
-      "integrity": "sha512-aMKtfOX9b1yx0ER0QspN2jOR/Q1ucRYEaR46yOUPjdcMHHnGxuk3kimsyGqgFm2+pPJdi9FRd9S2eC/tNjYn8w==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.178.0.tgz",
+      "integrity": "sha512-4OJgVeN2fBRHpRBNq1cCkT02QmsIZmiqsCXDgoRRlHJdcrbE5vLVs/PG/B1LB5ugxLD8EzwgoTbnOxIk0R1Weg==",
       "dependencies": {
-        "@aws-sdk/middleware-header-default": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.53.0.tgz",
-      "integrity": "sha512-g069Es0Sy3So2HRz+UAwaubFKkGuxwhEf6OS9pmovY2+2yfZBOLoQmf7jS50RgbxJcUDoI7uuKZrp0BcdLDgEg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.178.0.tgz",
+      "integrity": "sha512-nd9mvl7uF3S3ok4u9O/Avlc5d9YL8/OMDnKBoGeIYuop5bAdcO1t/sEJWEex6YYgtj0e20fIosO7maCXs8/C1A==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-header-default": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.53.0.tgz",
-      "integrity": "sha512-eQLFdNBzydZoocnj7YDVO+AJZ3YhuImZ1GXzGsF9FN8IdSjuE4gwB8BQhG6vuUg3GVe+sI+7VUJT6h55OaDBXw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
-      "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.178.0.tgz",
+      "integrity": "sha512-EFc9S63iwCmudVpVSiVPiTnp6WCfsRYUmTrZJJouZzthEhJwcrunwu7Fa9lHYb0zcWLgVFLhzs1Z34J/Er4JoQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.53.0.tgz",
-      "integrity": "sha512-HtBy8L3XNbovHLVh6wtIIThsbdTsX+jv09M9Cmmu80eM1WXw5Uu6lJX6FdIQXfMXBTZjnmHRL+72CxEtsets8g==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.178.0.tgz",
+      "integrity": "sha512-0Zrcdy75Q1CpAfjOFddiZSvK5iyeyh6fI7YRpUC8Fa3H+1kgW5sHESw0zyoC0NMAQkp1TgFrgxpaBuhAkdUzkg==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
-      "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.178.0.tgz",
+      "integrity": "sha512-k4jnB+ryGiAhv6vyNFz2YoaVodldjkbz4mqDlVzhwEn77LT/TcwdBoown3cJD/45LEtiuPqeONoTcNCsuCkRFQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.178.0.tgz",
+      "integrity": "sha512-dVgSoP2Mer8A0JGaWgpC/f4vPyvHh7laES/u5sTy6RfwrR87oTx+uhKrc6eh+9NkMR2xdRyaNJAMIXwL5bsVzg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
-      "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.178.0.tgz",
+      "integrity": "sha512-glBXpAqt+4KQ7q8y2/kwDX2ujCvCSQok5rlAmUjaQjVPc3cX77QwATIRQTS2nBC4v9tfMc7yL64ZeRbx6n0RAQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/service-error-classification": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/service-error-classification": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -785,460 +806,442 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.53.0.tgz",
-      "integrity": "sha512-cq2NFixf5HBctPaUUMjV97M++q18e/WDrM61lN7eMHfdXW+TlYv4tVF9y9MaE7dpoNp7G0ORLsz05JdVdUI33g==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.178.0.tgz",
+      "integrity": "sha512-/4IMPfSCsHZ3nFPPOFdNh+KlKkQE7LhesaxHEZA8f4qn/AnzBJUQLQ7iN4uvE+mD/WjNDUhNXX3ZqDRVaI2a+w==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/signature-v4-crt": "^3.31.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
-      "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.179.0.tgz",
+      "integrity": "sha512-uU9UdG9ornvblXdLLNsZNpgMOA9vgFMB93zo3DL/Q6MPmYprZYyK7dUiA06i1pe4HP2gR3N3hxXwzmKU6Bjt6A==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
-      "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
+      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
-      "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.179.0.tgz",
+      "integrity": "sha512-rtB6t3w1Km3ngO1yoiEUqsobujcBk36oPs2fTUKTbmuTr+54YH3NF0zAwVJv08lpfAs56holtp+bYyAxZJIxSQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.53.0.tgz",
-      "integrity": "sha512-2p2QT3PNepUC5MwT+t0l9bf7MlRHw6DN6CLg4Dptgr3SFR2k8LjUp2S7dJqg4qrhXRiiO7lTZK57PaPPR90dFw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.178.0.tgz",
+      "integrity": "sha512-6TcOTv03X8ygg9XnGTN2nTC1gSNaSIPBFvvQntVGr08umIajtalnI+2a9F3/+DQkUk/3u/V5j39mL9m0oAiMVw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
-      "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
+      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
-      "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.178.0.tgz",
+      "integrity": "sha512-xkKBxrFbs+UwUPpfIGEPuHeBWS2Jgmcd+ipEJUQRR3lY4h1fJ6mPGeyyaVDvwaJp9KgESSI6QTp6V15l8GXXgQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
-      "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.178.0.tgz",
+      "integrity": "sha512-yb5XJcC7SxkZ5oxu3zQ/foBdMkLBKryzx/CVg5BNSsKDjfbouf/ZYPcJDHhc2gzCtZcx18GjFBOnv8cpo/tyXQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
-      "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.178.0.tgz",
+      "integrity": "sha512-EtH6YiX1IX0QraQ/+kKBWAEtsFYBnFyxOimTBtlpDYwFpgDzIZ1GFn2wORYomEWALg10kphs8n3E5/7b5t5OWQ==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/querystring-builder": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
-      "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.178.0.tgz",
+      "integrity": "sha512-+Fh1aUANa+Gt/rh4SUHO0yHwKsibyZGk2LLDUcM1+9r0pUZT0qy3h0UCl5Kkj9HUcDJMD73wHTx4UB440xRobw==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
-      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
+      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
-      "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
+      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
-      "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
+      "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.182.0.tgz",
+      "integrity": "sha512-//pDrBCSXqBSJ1Xi5GhAaeY5M1yHNTytNuTmBkKSSorAwZ7cbnSmVhegXQdVXvNIRBex+nqIvKzYR9Tgt1IxVA==",
+      "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.182.0",
+        "@aws-sdk/middleware-sdk-s3": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4-multi-region": "3.180.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-create-request": "3.180.0",
+        "@aws-sdk/util-format-url": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
-      "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.178.0.tgz",
+      "integrity": "sha512-tDKTBXxck2N4bhAnQaeokx9ps38V3G70lcDdHS/N9hmqcQQmH5x+1/AMwYWLjUZmOQPBW9sFoG4B3psnl+sefw==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.178.0.tgz",
+      "integrity": "sha512-nZGmuhGLDFbXsb7QYDg7PiPMAmsdlSshKJ+AhKSZF/J0SK94kdZgGnGXGUZe52S3G41E3CZIgnLnnsMXq0uErA==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
-      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
+      "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-crt": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.110.0.tgz",
-      "integrity": "sha512-J+AF33N46iSRNM7uFcbAVhCDbUk7TQt02b5wPDDhBlIjefp/1VnHaHuOv/cDYbQqe+pj6YQD3u9pI5JMPtqQeA==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.180.0.tgz",
+      "integrity": "sha512-zO7UQNiyb6VKC2W8W7G4gJj75p0xgT03TNxt3JGJbA22Pp07C/aBUtwrEs+JBjrm0i8UQfPjgUNZcUFrO/s7BA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/querystring-parser": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "aws-crt": "^1.12.2",
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "aws-crt": "^1.13.2",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-      "peer": true,
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.180.0.tgz",
+      "integrity": "sha512-3IjwOy/x6UroV3TAbeCwpCRmt/8TW89JI1r8gtDbpQ42WiQ/1J+R5a78NP8bYa53kiDghW6pKlvLcbuoh3zWHQ==",
       "dependencies": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.110.0.tgz",
-      "integrity": "sha512-//pJHH7hrhdDMZGBPKXKymmC/tJM7gFT0w/qbu/yd3Wm4W2fMB+8gkmj6EZctx7jrsWlfRQuvFejKqEfapur/g==",
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.110.0",
-        "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.110.0.tgz",
-      "integrity": "sha512-utxxdllOnmQDhbpipnFAbuQ4c2pwefZ+2hi48jKvQRULQ2PO4nxLmdZm6B0FXaTijbKsyO7GrMik+EZ6mi3ARQ==",
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
       },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/types": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
-      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.109.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
-      "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
-      "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
+      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
-      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
+      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
-      "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
+      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
-      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.170.0.tgz",
+      "integrity": "sha512-2ivABL9GNsucfMMkgGjVdFidbDogtSr4FBVW12D4ltijOL82CAynGrnxHAczRGnmi5/1/Ir4ipkr9pAdRMGiGw==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz",
+      "integrity": "sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
-      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz",
+      "integrity": "sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-      "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz",
+      "integrity": "sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-      "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz",
+      "integrity": "sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
-      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
+      "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
+      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-credentials": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
-      "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+    "node_modules/@aws-sdk/util-create-request": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.180.0.tgz",
+      "integrity": "sha512-wBYsn+oCCNwJvltTp0hE6PzV+yZCV4orZJvpVm9AlpuXHL0NL9Xr8vMx1v9zTxG7v0aNIWIG5I/JZXwNDzkg3Q==",
       "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
-      "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.180.0.tgz",
+      "integrity": "sha512-XGq/RUuhqnLlApETBmBWDszNG4TR3FCOSNwFvok1UIPgFXxjh0JOzNc5mAX1St2hfx1IDb9Ja4BmTkYKix7byg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
-      "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.180.0.tgz",
+      "integrity": "sha512-ch9VR4OKYGEaNbLhX/EyZDpNZst5T+/VYsFyqMA47J0YyMbg7GWyn2FjjhZ7qOV3XU6W8YEBNdd7U/LFFVp8uA==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.178.0.tgz",
+      "integrity": "sha512-otKBGoj4QDNdXNDUV6nTCWbAlqmrjGb6YddbwkM5lZuisLf51HE7oQnEDX6k0SRvLTq3Xk+JE7pa2RlkMfV2gQ==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
+      "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1256,10 +1259,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.110.0.tgz",
-      "integrity": "sha512-PTVWrI5fA9d5hHJs6RzX2dIS2jRQ3uW073Fm0BePpQeDdZrEk+S5KNwRhUtpN6sdSV45vm6S9rrjZUG51qwGmA==",
-      "peer": true,
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
+      "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1268,99 +1270,113 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.53.0.tgz",
-      "integrity": "sha512-oh+PVTeo7nvkuXwlrAy6TErTpzTRrtxaL+2ErTFiLFPPFKK2/0X0E12zoNB0DMaY48sRdkJmrlLbOtxGDS1rNg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.178.0.tgz",
+      "integrity": "sha512-CgXIJjDtkJPpig3/37xNzwPvtySN21m3nI/61CDjmQTFU9CfrfFplR/K3yBhB465AyINrLcDyuiBBcv78wqBzg==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.53.0.tgz",
-      "integrity": "sha512-Hubb2cvn2idlNsHkJ5v46wW+cvodLySGJCqTat5kUAoOxR20ZFG3P3R6InU85PAh54zZTRvURuD0UM0uPtIQYQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.178.0.tgz",
+      "integrity": "sha512-SarpMLzoG49Tosp+s+yMsE2rGwsDqa6NDP6umqo2HXX3D26I3uqaefoB0E+Jn/VAJZcKbwxRZUPKnwQEOn1xMA==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
+      "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
-      "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.178.0.tgz",
+      "integrity": "sha512-LxOrn7Ai88n0i5J5rTb5Bt0TAycPvDYzjdCwmd2mahsPHZGSDLeCeh6KOIxZsEfnzYRl4HGWvIEXdHIYZ3RTug==",
       "dependencies": {
-        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/types": "3.178.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
-      "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.178.0.tgz",
+      "integrity": "sha512-TrP6v+V4Qnv3E9CNgwR/G+1xiy8fa9j5LAm43qwp9PfJHchNyWOJ0FURD3Ne2sm/388Ybzjb1DRYRZ7B+xbnOw==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
-      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
+      "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
-      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
+      "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
-      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.180.0.tgz",
+      "integrity": "sha512-fDBGplYp6pIIfrB7073tUhU4zppRaSiPjBCCT00yth9woWwZPUCIg7iQZKEqkBmvCzcJSYn0jRopLhf3Y7i5Wg==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
-      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.170.0.tgz",
+      "integrity": "sha512-eN458rrukeI62yU1k4a+032IfpAS7aK30VEITzKanklMW6AxTpxUC6vGrP6bwtIpCFDN8yVaIiAwGXQg5l1X4g==",
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -2211,6 +2227,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.1.tgz",
       "integrity": "sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/ws": "*",
@@ -2227,6 +2244,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -2239,6 +2257,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -2254,12 +2273,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "optional": true,
       "peer": true
     },
     "node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -2865,7 +2886,8 @@
     "node_modules/@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "devOptional": true
     },
     "node_modules/@types/pg": {
       "version": "8.6.4",
@@ -2906,6 +2928,7 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
       "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -3203,6 +3226,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
+      "optional": true,
       "peer": true
     },
     "node_modules/ansi-escapes": {
@@ -3271,6 +3295,50 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
+    "node_modules/are-we-there-yet": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -3294,8 +3362,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -3316,29 +3383,39 @@
       }
     },
     "node_modules/aws-crt": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.12.4.tgz",
-      "integrity": "sha512-BqvCb016EHVQV7P50x8VyqB5cgYrsFOEZoZdCaBrGc/cZTGRrFQOfbpPbuivgRHg55e7b1cFkgXDG88jdmOURw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.14.4.tgz",
+      "integrity": "sha512-ZAjZ4sg4GVN4W/P3r6CgcMcY4qp9gGuRxi5e/vSbNX6eI5wte2jN9i6HgPrmoRLiXbmt9b6CLF4lc91U1O7snA==",
       "hasInstallScript": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
+        "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",
         "axios": "^0.24.0",
-        "cmake-js": "6.3.0",
+        "cmake-js": "^6.3.2",
         "crypto-js": "^4.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.3.4",
-        "tar": "^6.1.11",
-        "ws": "^7.5.5"
+        "mqtt": "^4.3.7",
+        "tar": "^6.1.11"
       }
     },
-    "node_modules/axios": {
+    "node_modules/aws-crt/node_modules/axios": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3487,6 +3564,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffers": "~0.1.1",
@@ -3514,6 +3592,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3522,9 +3601,10 @@
       }
     },
     "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "optional": true,
       "peer": true
     },
     "node_modules/bowser": {
@@ -3536,6 +3616,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3619,12 +3700,14 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "devOptional": true
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
       "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10"
@@ -3634,6 +3717,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
+      "optional": true,
       "peer": true
     },
     "node_modules/buffer-writer": {
@@ -3648,6 +3732,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.2.0"
@@ -3691,6 +3776,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
@@ -3785,10 +3871,14 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "peer": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ci-info": {
       "version": "3.3.2",
@@ -3814,12 +3904,14 @@
       }
     },
     "node_modules/cmake-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
-      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.2.tgz",
+      "integrity": "sha512-7MfiQ/ijzeE2kO+WFB9bv4QP5Dn2yVaAP2acFJr4NIFy2hT4w6O4EpOTLNcohR5IPX7M4wNf/5taIqMj7UA9ug==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "axios": "^0.21.1",
+        "bluebird": "^3",
         "debug": "^4",
         "fs-extra": "^5.0.0",
         "is-iojs": "^1.0.1",
@@ -3846,25 +3938,17 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/are-we-there-yet": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.0 || ^1.1.13"
       }
     },
     "node_modules/cmake-js/node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
@@ -3874,15 +3958,24 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cmake-js/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cmake-js/node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -3894,6 +3987,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -3905,28 +3999,17 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^2.6.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
-      "peer": true,
-      "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
       }
     },
     "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -3939,6 +4022,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optional": true,
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -3948,6 +4032,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -3958,6 +4043,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^2.9.0"
@@ -3967,6 +4053,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
@@ -3975,66 +4062,21 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/cmake-js/node_modules/npmlog": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
-      "peer": true,
-      "dependencies": {
-        "ansi": "~0.3.0",
-        "are-we-there-yet": "~1.0.0",
-        "gauge": "~1.2.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cmake-js/node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "peer": true
-    },
     "node_modules/cmake-js/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "optional": true,
       "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/cmake-js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "peer": true
-    },
     "node_modules/cmake-js/node_modules/string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -4049,6 +4091,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -4061,6 +4104,7 @@
       "version": "4.4.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
       "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "chownr": "^1.1.4",
@@ -4079,6 +4123,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -4088,6 +4133,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4100,6 +4146,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -4113,18 +4160,21 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
       "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/cmake-js/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "optional": true,
       "peer": true
     },
     "node_modules/cmake-js/node_modules/yargs": {
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "camelcase": "^2.0.1",
@@ -4149,7 +4199,8 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4180,7 +4231,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4200,6 +4250,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
       "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "leven": "^2.1.0",
@@ -4209,7 +4260,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "devOptional": true
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -4218,6 +4270,7 @@
       "engines": [
         "node >= 6.0"
       ],
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -4264,6 +4317,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/create-require": {
@@ -4328,6 +4382,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4348,6 +4403,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=4.0.0"
@@ -4371,7 +4427,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4379,7 +4434,8 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/detect-newline": {
@@ -4445,6 +4501,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
@@ -4454,6 +4511,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -4469,12 +4527,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "optional": true,
       "peer": true
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -5059,12 +5119,6 @@
         "url": "https://paypal.me/naturalintelligence"
       }
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "peer": true
-    },
     "node_modules/fastify": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.2.1.tgz",
@@ -5250,7 +5304,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5293,6 +5346,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
@@ -5336,6 +5390,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5351,6 +5406,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
@@ -5363,6 +5419,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -5381,6 +5438,20 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -5430,6 +5501,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "devOptional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5520,13 +5592,15 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/help-me": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
       "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "glob": "^7.1.6",
@@ -5646,6 +5720,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true,
       "peer": true
     },
     "node_modules/interpret": {
@@ -5660,6 +5735,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5745,6 +5821,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
       "integrity": "sha512-tLn1j3wYSL6DkvEI+V/j0pKohpa5jk+ER74v6S4SgCXnjS0WA+DoZbwZBrrhgwksMvtuwndyGeG5F8YMsoBzSA==",
+      "optional": true,
       "peer": true
     },
     "node_modules/is-number": {
@@ -5771,18 +5848,21 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "devOptional": true
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "optional": true,
       "peer": true,
       "peerDependencies": {
         "ws": "*"
@@ -6447,9 +6527,10 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
-      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "optional": true,
       "peer": true
     },
     "node_modules/js-tokens": {
@@ -6685,6 +6766,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -6696,7 +6778,8 @@
     "node_modules/leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6740,6 +6823,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/locate-path": {
@@ -6810,18 +6894,21 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
       "integrity": "sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg==",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.padstart": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
+      "optional": true,
       "peer": true
     },
     "node_modules/logflare-transport-core": {
@@ -6899,6 +6986,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
       "integrity": "sha512-q0D3m846qY6ZkIt+19ZemU5vH56lpOZZwoJc3AICARKh/menBuayQUjAGPrqtHQQMUYERSdOrej92J9kz7LgYA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "readable-stream": "~1.0.26-2"
@@ -6908,12 +6996,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/memory-stream/node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -6926,6 +7016,7 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/merge-stream": {
@@ -6971,7 +7062,6 @@
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
       "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6980,7 +7070,6 @@
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
       "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.46.0"
       },
@@ -7001,6 +7090,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7011,12 +7101,14 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "devOptional": true
     },
     "node_modules/minipass": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
-      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -7029,6 +7121,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
@@ -7042,6 +7135,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "devOptional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -7053,6 +7147,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
       "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "commist": "^1.0.0",
@@ -7086,6 +7181,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
       "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "bl": "^4.0.2",
@@ -7097,9 +7193,32 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ms": {
@@ -7184,20 +7303,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi": "~0.3.0",
+        "are-we-there-yet": "~1.0.0",
+        "gauge": "~1.2.0"
+      }
+    },
     "node_modules/number-allocator": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
-      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.12.tgz",
+      "integrity": "sha512-sGB0qoQGmKimery9JubBQ9pQUr1V/LixJAk3Ygp7obZf6mpSXime8d7XHEobbIimkdZpgjkNlLt6G7LPEWFYWg==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.3.1",
-        "js-sdsl": "^2.1.2"
+        "js-sdsl": "4.1.4"
       }
     },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7252,6 +7385,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -7358,6 +7492,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7864,6 +7999,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "optional": true,
       "peer": true
     },
     "node_modules/process-warning": {
@@ -7971,6 +8107,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -7985,7 +8122,8 @@
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8057,6 +8195,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
       "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/require-directory": {
@@ -8254,6 +8393,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "optional": true,
       "peer": true
     },
     "node_modules/setprototypeof": {
@@ -8342,6 +8482,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
       "integrity": "sha512-UUFYD2oWbNwULH6WoVtLUOw8ch586B+HUqcsAjjjeoBQAM1bD4wZRXu01koaxyd8UeYpybWqW4h+lO1Okv40Tg==",
+      "optional": true,
       "peer": true
     },
     "node_modules/sprintf-js": {
@@ -8509,6 +8650,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -8520,15 +8662,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tarn": {
@@ -8660,6 +8793,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "*"
@@ -8902,6 +9036,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "optional": true,
       "peer": true
     },
     "node_modules/typescript": {
@@ -8929,6 +9064,7 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
       "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "big-integer": "^1.6.17",
@@ -8942,16 +9078,25 @@
         "setimmediate": "~1.0.4"
       }
     },
+    "node_modules/unzipper/node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/unzipper/node_modules/process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
+      "optional": true,
       "peer": true
     },
     "node_modules/unzipper/node_modules/readable-stream": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
       "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-shims": "^1.0.0",
@@ -8967,6 +9112,7 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "optional": true,
       "peer": true
     },
     "node_modules/update-browserslist-db": {
@@ -9007,6 +9153,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
       "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "optional": true,
       "peer": true
     },
     "node_modules/util-deprecate": {
@@ -9078,6 +9225,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
+      "optional": true,
       "peer": true,
       "bin": {
         "window-size": "cli.js"
@@ -9164,12 +9312,13 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "optional": true,
       "peer": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -9389,11 +9538,11 @@
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -9406,855 +9555,855 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
-      "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.178.0.tgz",
+      "integrity": "sha512-ptDkCB06BJrYdhKzamM9yI15LxcGkPczY80hzKAY/aecm09alnW27uCt5HJJx2nCd18IUH28ZO1sc7DTLOWb3A==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
-      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.170.0.tgz",
+      "integrity": "sha512-73Fy1u9zR9ZMC59QobuCWg3LoYfcrFsrP8569vvqtlGqPuQUW+RW3gfx0omIDmxaSg8qq8REPLJFrAGfeL7VtQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
-      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.170.0.tgz",
+      "integrity": "sha512-haJ7fdWaOgAM4trw2LBd1VIvRFzMMPz2jy9mu4rE+z1uHbPZHNMGytBo1FJO2DShzUCmJZi3t3CD/7aE3H38+w==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.53.0.tgz",
-      "integrity": "sha512-2RSGn8ggS1Uu2f/n1IAhPNShlXMoof2uyjr/N236uVvyQHwxmsG/yJCc/lYJHSZyIBlYhqBiQ0DGGV2QuwzS8A==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.181.0.tgz",
+      "integrity": "sha512-EUJ/Y8SWALh5bfxcg+LQytpI/R3KXHYilWRnBBsKLBUfAWPj+8NzZdDK8wD/6htBtAV4XnqHux3cMCnpeoRf8g==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.53.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-node": "3.53.0",
-        "@aws-sdk/eventstream-serde-browser": "3.53.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.53.0",
-        "@aws-sdk/eventstream-serde-node": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-blob-browser": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/hash-stream-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/md5-js": "3.53.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-expect-continue": "3.53.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-location-constraint": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-sdk-s3": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/middleware-ssec": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-stream-browser": "3.53.0",
-        "@aws-sdk/util-stream-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.53.0",
-        "@aws-sdk/xml-builder": "3.52.0",
+        "@aws-sdk/client-sts": "3.181.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/eventstream-serde-browser": "3.178.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.178.0",
+        "@aws-sdk/eventstream-serde-node": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-blob-browser": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/hash-stream-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/md5-js": "3.178.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-expect-continue": "3.178.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-location-constraint": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-s3": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-ssec": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4-multi-region": "3.180.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-stream-browser": "3.178.0",
+        "@aws-sdk/util-stream-node": "3.178.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "@aws-sdk/util-waiter": "3.180.0",
+        "@aws-sdk/xml-builder": "3.170.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
-      "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.181.0.tgz",
+      "integrity": "sha512-p/HsYVAO7fgjFfn4LqlnlpSKPXGPegAwjPpY+SqyK3/Hj1OtED4whG8LTgxZSTtYwNIkHEjrHnXTiymyXh34Aw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
-      "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.181.0.tgz",
+      "integrity": "sha512-j//F9kjdSv9lUa8p87cg+xk6l5E8o8+GTYP5838eFQR7XcEc3yEljSCkuj2xIzrtf1jKuMXBnswTKmxJhjbTzQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-node": "3.53.0",
-        "@aws-sdk/fetch-http-handler": "3.53.0",
-        "@aws-sdk/hash-node": "3.53.0",
-        "@aws-sdk/invalid-dependency": "3.53.0",
-        "@aws-sdk/middleware-content-length": "3.53.0",
-        "@aws-sdk/middleware-host-header": "3.53.0",
-        "@aws-sdk/middleware-logger": "3.53.0",
-        "@aws-sdk/middleware-retry": "3.53.0",
-        "@aws-sdk/middleware-sdk-sts": "3.53.0",
-        "@aws-sdk/middleware-serde": "3.53.0",
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/middleware-user-agent": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/node-http-handler": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/smithy-client": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
-        "@aws-sdk/util-defaults-mode-node": "3.53.0",
-        "@aws-sdk/util-user-agent-browser": "3.53.0",
-        "@aws-sdk/util-user-agent-node": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-node": "3.181.0",
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/hash-node": "3.178.0",
+        "@aws-sdk/invalid-dependency": "3.178.0",
+        "@aws-sdk/middleware-content-length": "3.178.0",
+        "@aws-sdk/middleware-host-header": "3.178.0",
+        "@aws-sdk/middleware-logger": "3.178.0",
+        "@aws-sdk/middleware-recursion-detection": "3.178.0",
+        "@aws-sdk/middleware-retry": "3.178.0",
+        "@aws-sdk/middleware-sdk-sts": "3.179.0",
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/middleware-user-agent": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-base64-node": "3.170.0",
+        "@aws-sdk/util-body-length-browser": "3.170.0",
+        "@aws-sdk/util-body-length-node": "3.170.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.180.0",
+        "@aws-sdk/util-defaults-mode-node": "3.180.0",
+        "@aws-sdk/util-user-agent-browser": "3.178.0",
+        "@aws-sdk/util-user-agent-node": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
-      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.178.0.tgz",
+      "integrity": "sha512-8xL98TGMaVULIN7HRWV2q1o0Y2p38QuweehzM8yXCZrrLOyHgWo3waP2RNVeddOB7MrSwwU/gw9rXSv7YHLZ6w==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
-      "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.178.0.tgz",
+      "integrity": "sha512-5CMswTJ188RuK9TmI5yAosIsyu4Mm9Cdq1068tRls5EqqwGK1PI7Q007b6rD7zqCb5IgeFBV0t2DxHkBmHRd3w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
-      "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.178.0.tgz",
+      "integrity": "sha512-ZvqQTi3+S13LACVgaWNCOKBv5jROIz7rqyZh56QunAkaAUqPbpM4VFODgAGZYPCOSggZbEUUqXOVB9xSnshLnA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/url-parser": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
-      "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.181.0.tgz",
+      "integrity": "sha512-jOa42qYFgkdMumw0IRO0ASAjM0vZMXvPpy3DGOaG0Ehy4KHeykEj4/J23SxCTCkOqAbz2+8XVCuyTExUmWCuWw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/credential-provider-sso": "3.53.0",
-        "@aws-sdk/credential-provider-web-identity": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
-      "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.181.0.tgz",
+      "integrity": "sha512-RlLdp+7faCKzJsmUlBSr4CjqN9WG+YZpmuVVlW5fXGUdXLBLEvLMTl5rmwKtRSUytyYK0Vqtmt48I4nBze8MrA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/credential-provider-ini": "3.53.0",
-        "@aws-sdk/credential-provider-process": "3.53.0",
-        "@aws-sdk/credential-provider-sso": "3.53.0",
-        "@aws-sdk/credential-provider-web-identity": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/credential-provider-ini": "3.181.0",
+        "@aws-sdk/credential-provider-process": "3.178.0",
+        "@aws-sdk/credential-provider-sso": "3.181.0",
+        "@aws-sdk/credential-provider-web-identity": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
-      "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.178.0.tgz",
+      "integrity": "sha512-J4TldKrAnfayvRfxNEnLJUnTgkpTcct6rc7PwZlVSGSUgjglbcqfemUOP/pisLKbVNNL742lsUXmkUVH4km0Fw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
-      "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+      "version": "3.181.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.181.0.tgz",
+      "integrity": "sha512-03YAvns+P7hw5rLwYLExezn9iGX9HD2GAKCEgpSaZSlNLzMw0jU7VEmqJvrLqi+xAoshuRR5A3v8HFQU246QRA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-credentials": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sso": "3.181.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
-      "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.178.0.tgz",
+      "integrity": "sha512-aei8o9ALtzwgYsZCAWdr+ItJyYTkYRmCoKstM4mkGtWNK9BjdISaVUAnndl6Pc/l/5eiK+2rlA+6Ujs4H8m+XQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/eventstream-marshaller": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.53.0.tgz",
-      "integrity": "sha512-Vt8OjC0hgF0rNcGPbMEROnM5SHODzRdQsG9Y+M2suWDkUqFoh8+6m4v9c/ej3iudAEydZDLcnpV9yGv/CTqceg==",
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.178.0.tgz",
+      "integrity": "sha512-x18waxfidmI9i4BLpnwV37rxHPyyviyWo5qRgYWX+gLxhN6Z6sB3/Pc/s8/yQmywMs6/DlMBYJUDTvYXR1cezA==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.53.0.tgz",
-      "integrity": "sha512-B+nAlXet/NSEIzaN4fZYGwoFHBYtURuXUE+Ru4EaWyC8+vBEdeO4Vs9o/8mlZSHGiUn41QYYqiZvd+OKweTtBA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.178.0.tgz",
+      "integrity": "sha512-UMlCevpJoQ8oMlNKlQF0Ti5zIztLzx9zcrxfi4KK1A22qXamTA5kHloyq1mFwrTkbcr4uhQ9omDDx//hYQ+yNw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/eventstream-serde-universal": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.53.0.tgz",
-      "integrity": "sha512-4O66c1aSgfdWfbr2pUJTONReVwA4oWQ/fRMhcAMhacqbPko5+3v0Iy/vOiVCm6Isa4K2kVpOUN0L+64niE7jag==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.178.0.tgz",
+      "integrity": "sha512-LmH5JuNCOvUI2g/7e2qlvHqRQW316J5iTawZQd233xUlmRO49kHc8HFvKPo98/V/S4MFsjlrZF9dcnly2txCxw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.53.0.tgz",
-      "integrity": "sha512-92rlY8M8+nU4mUm3j4gtJiv9HY2fGTGLSIGLukOXAUf7xuJ220L+9ZInS4ToiRgq+dOSt8cFPCxRVpQtNesBfA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.178.0.tgz",
+      "integrity": "sha512-YsFoZ8MlVReGm7GKMjvo5vxLVo/ZPSDg6ckp7kff18zZMlbNtuK+zfgub3tX1f2hbDoV2bBVL3xuZJkeBELpHQ==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/eventstream-serde-universal": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.53.0.tgz",
-      "integrity": "sha512-Y3OjTAKhDyz2UyLE0ATmDD3RFyBfJLWeBQkpJu7qICI0XYN2tmV1mCkQUtkT3e4s+UxnuUOa55YQpdUsQUWIDA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.178.0.tgz",
+      "integrity": "sha512-Rd8QjqzN2roSHsLn0y1iCt/KrEQL2qlNdunXRjBwXvjZGuODa6M8gpOvaPNpTWLiD+V6mO0zuPp+tWiLZxMndw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-codec": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
-      "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.178.0.tgz",
+      "integrity": "sha512-T/LCNwCihdVNzGn39Dw7tk2U1fMlupFlCsAvDBbO+FOM3h+y9WLHzxmlAVsjPrFXlzdONKf9zd5cuQ+ZW93yAQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/querystring-builder": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.53.0.tgz",
-      "integrity": "sha512-A3xa0o1W9/tALw0/yoXyBKfxsMlzi1BvzEgCFUU2y914yBo62FiIf1E+BX42m9MfPJ87SD+l3O5QcptMVWvarw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.178.0.tgz",
+      "integrity": "sha512-LgrKDNi56q3ayxcvbC0MMt/fgliKgMb8G2o1y6bUAKzlEtBHLFfTUjvzW1WsDfK8ZSrtz/bZNGECIjeFEdTggQ==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.52.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/chunked-blob-reader": "3.170.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
-      "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.178.0.tgz",
+      "integrity": "sha512-mqYraRQlvPO5egUKTNZ1kP52sfwBlsz7woOewQTHOGomZBDXrh8bl1J+sgaDi1NAwXdZUgxuD3QKxxAKRs9a2Q==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.53.0.tgz",
-      "integrity": "sha512-AggSL/LQ/B1T9Ho+EVKlTmuSe/hE74KFNCQWXJUF21zYVZY7ssUd67lEpzCWkhNgcCqt8TE5uE7S0scPA/vDxw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.178.0.tgz",
+      "integrity": "sha512-YzockpOajp5WOweB+/hIrQy9KNVXEgnbMDcuCmevYfoub+BJbjCs5eAZrhCJBkXpRKBz3X1U0vlYp7twFacPqw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
-      "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.178.0.tgz",
+      "integrity": "sha512-JJNaiLr3nbRYym6oUAAaoFFYtDnIZ9Scco2p4sG/thT2eyAfXcEdNl1cSD3E/R1J+Ml/YplqTiIY4u1KPAriRw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
+      "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.53.0.tgz",
-      "integrity": "sha512-fXhpbkC0tZAQat9xE73XjYBiw5gmrcJ/0ctkeSJtGsXsvwxalw0esk7i1paNsL2zoWNoib1M/vUNTcsKGW725A==",
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.182.0.tgz",
+      "integrity": "sha512-12MleBxo9f74R1x4rvVYEkyJyUtp+YNbpCSR+8v7VuBJm0LVugCbKRasle+xmWsWI/Pd20OXalzManWZIWMQDA==",
       "requires": {
+        "@aws-sdk/middleware-endpoint": "3.182.0",
+        "@aws-sdk/smithy-client": "3.180.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
-      "integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.178.0.tgz",
+      "integrity": "sha512-o/F4QKjJL2gQdGq5eQnVGc9SlJ+/TjUBDJfn0Nyz4/OhDYVRvf4yJLT3+I9ZQN5M6DoFgqrLPH0MUHv4EmDPpw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "@aws-sdk/util-utf8-node": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.53.0.tgz",
-      "integrity": "sha512-q88eevXUkUWp6e/vHGnpt8/8TjscbfW6CWGpexj3DFWt3WZhEhExcoGwwszoL4FQfMFWBL+11EKNZm2orHqDwg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.178.0.tgz",
+      "integrity": "sha512-HCHonBmv5SWZMZqVNtWr73d6moZfcqTI87Xmi0Ofpra8tmu99WQpYgXmVLqK13wlPP2MJErBLkcDt15dsS0pJw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
-      "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.178.0.tgz",
+      "integrity": "sha512-p3n3IzU03eRzZivEoQn1HA83LbAKukZwRevsJpya1UfCUtWkXQO3v0jU8rhZE4deGa9k7zuCAEmJ8nCw3QxclQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.182.0.tgz",
+      "integrity": "sha512-F51nTuxdZ0oTuqU2+Ca+l/Ysvn6ukLyujvHhyJfolquKX+ra/CBEC/Unhksl7ORolehm+iwbryyO7MHq7BWGkA==",
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/url-parser": "3.178.0",
+        "@aws-sdk/util-config-provider": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.53.0.tgz",
-      "integrity": "sha512-aMKtfOX9b1yx0ER0QspN2jOR/Q1ucRYEaR46yOUPjdcMHHnGxuk3kimsyGqgFm2+pPJdi9FRd9S2eC/tNjYn8w==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.178.0.tgz",
+      "integrity": "sha512-4OJgVeN2fBRHpRBNq1cCkT02QmsIZmiqsCXDgoRRlHJdcrbE5vLVs/PG/B1LB5ugxLD8EzwgoTbnOxIk0R1Weg==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.53.0.tgz",
-      "integrity": "sha512-g069Es0Sy3So2HRz+UAwaubFKkGuxwhEf6OS9pmovY2+2yfZBOLoQmf7jS50RgbxJcUDoI7uuKZrp0BcdLDgEg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.178.0.tgz",
+      "integrity": "sha512-nd9mvl7uF3S3ok4u9O/Avlc5d9YL8/OMDnKBoGeIYuop5bAdcO1t/sEJWEex6YYgtj0e20fIosO7maCXs8/C1A==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/middleware-header-default": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.53.0.tgz",
-      "integrity": "sha512-eQLFdNBzydZoocnj7YDVO+AJZ3YhuImZ1GXzGsF9FN8IdSjuE4gwB8BQhG6vuUg3GVe+sI+7VUJT6h55OaDBXw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
-      "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.178.0.tgz",
+      "integrity": "sha512-EFc9S63iwCmudVpVSiVPiTnp6WCfsRYUmTrZJJouZzthEhJwcrunwu7Fa9lHYb0zcWLgVFLhzs1Z34J/Er4JoQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.53.0.tgz",
-      "integrity": "sha512-HtBy8L3XNbovHLVh6wtIIThsbdTsX+jv09M9Cmmu80eM1WXw5Uu6lJX6FdIQXfMXBTZjnmHRL+72CxEtsets8g==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.178.0.tgz",
+      "integrity": "sha512-0Zrcdy75Q1CpAfjOFddiZSvK5iyeyh6fI7YRpUC8Fa3H+1kgW5sHESw0zyoC0NMAQkp1TgFrgxpaBuhAkdUzkg==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
-      "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.178.0.tgz",
+      "integrity": "sha512-k4jnB+ryGiAhv6vyNFz2YoaVodldjkbz4mqDlVzhwEn77LT/TcwdBoown3cJD/45LEtiuPqeONoTcNCsuCkRFQ==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.178.0.tgz",
+      "integrity": "sha512-dVgSoP2Mer8A0JGaWgpC/f4vPyvHh7laES/u5sTy6RfwrR87oTx+uhKrc6eh+9NkMR2xdRyaNJAMIXwL5bsVzg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
-      "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.178.0.tgz",
+      "integrity": "sha512-glBXpAqt+4KQ7q8y2/kwDX2ujCvCSQok5rlAmUjaQjVPc3cX77QwATIRQTS2nBC4v9tfMc7yL64ZeRbx6n0RAQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/service-error-classification": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/service-error-classification": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.53.0.tgz",
-      "integrity": "sha512-cq2NFixf5HBctPaUUMjV97M++q18e/WDrM61lN7eMHfdXW+TlYv4tVF9y9MaE7dpoNp7G0ORLsz05JdVdUI33g==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.178.0.tgz",
+      "integrity": "sha512-/4IMPfSCsHZ3nFPPOFdNh+KlKkQE7LhesaxHEZA8f4qn/AnzBJUQLQ7iN4uvE+mD/WjNDUhNXX3ZqDRVaI2a+w==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
-      "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.179.0.tgz",
+      "integrity": "sha512-uU9UdG9ornvblXdLLNsZNpgMOA9vgFMB93zo3DL/Q6MPmYprZYyK7dUiA06i1pe4HP2gR3N3hxXwzmKU6Bjt6A==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-signing": "3.179.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
-      "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
+      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
-      "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+      "version": "3.179.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.179.0.tgz",
+      "integrity": "sha512-rtB6t3w1Km3ngO1yoiEUqsobujcBk36oPs2fTUKTbmuTr+54YH3NF0zAwVJv08lpfAs56holtp+bYyAxZJIxSQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/signature-v4": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.53.0.tgz",
-      "integrity": "sha512-2p2QT3PNepUC5MwT+t0l9bf7MlRHw6DN6CLg4Dptgr3SFR2k8LjUp2S7dJqg4qrhXRiiO7lTZK57PaPPR90dFw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.178.0.tgz",
+      "integrity": "sha512-6TcOTv03X8ygg9XnGTN2nTC1gSNaSIPBFvvQntVGr08umIajtalnI+2a9F3/+DQkUk/3u/V5j39mL9m0oAiMVw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
-      "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
+      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
-      "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.178.0.tgz",
+      "integrity": "sha512-xkKBxrFbs+UwUPpfIGEPuHeBWS2Jgmcd+ipEJUQRR3lY4h1fJ6mPGeyyaVDvwaJp9KgESSI6QTp6V15l8GXXgQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
-      "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.178.0.tgz",
+      "integrity": "sha512-yb5XJcC7SxkZ5oxu3zQ/foBdMkLBKryzx/CVg5BNSsKDjfbouf/ZYPcJDHhc2gzCtZcx18GjFBOnv8cpo/tyXQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/shared-ini-file-loader": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
-      "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.178.0.tgz",
+      "integrity": "sha512-EtH6YiX1IX0QraQ/+kKBWAEtsFYBnFyxOimTBtlpDYwFpgDzIZ1GFn2wORYomEWALg10kphs8n3E5/7b5t5OWQ==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.53.0",
-        "@aws-sdk/protocol-http": "3.53.0",
-        "@aws-sdk/querystring-builder": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
-      "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.178.0.tgz",
+      "integrity": "sha512-+Fh1aUANa+Gt/rh4SUHO0yHwKsibyZGk2LLDUcM1+9r0pUZT0qy3h0UCl5Kkj9HUcDJMD73wHTx4UB440xRobw==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
-      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
+      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
-      "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
+      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
-      "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
+      "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.182.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.182.0.tgz",
+      "integrity": "sha512-//pDrBCSXqBSJ1Xi5GhAaeY5M1yHNTytNuTmBkKSSorAwZ7cbnSmVhegXQdVXvNIRBex+nqIvKzYR9Tgt1IxVA==",
+      "requires": {
+        "@aws-sdk/middleware-endpoint": "3.182.0",
+        "@aws-sdk/middleware-sdk-s3": "3.178.0",
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4-multi-region": "3.180.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-create-request": "3.180.0",
+        "@aws-sdk/util-format-url": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
-      "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.178.0.tgz",
+      "integrity": "sha512-tDKTBXxck2N4bhAnQaeokx9ps38V3G70lcDdHS/N9hmqcQQmH5x+1/AMwYWLjUZmOQPBW9sFoG4B3psnl+sefw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.178.0.tgz",
+      "integrity": "sha512-nZGmuhGLDFbXsb7QYDg7PiPMAmsdlSshKJ+AhKSZF/J0SK94kdZgGnGXGUZe52S3G41E3CZIgnLnnsMXq0uErA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
-      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
+      "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.53.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4-crt": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.110.0.tgz",
-      "integrity": "sha512-J+AF33N46iSRNM7uFcbAVhCDbUk7TQt02b5wPDDhBlIjefp/1VnHaHuOv/cDYbQqe+pj6YQD3u9pI5JMPtqQeA==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.180.0.tgz",
+      "integrity": "sha512-zO7UQNiyb6VKC2W8W7G4gJj75p0xgT03TNxt3JGJbA22Pp07C/aBUtwrEs+JBjrm0i8UQfPjgUNZcUFrO/s7BA==",
+      "optional": true,
       "peer": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/querystring-parser": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "aws-crt": "^1.12.2",
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-middleware": "3.178.0",
+        "@aws-sdk/util-uri-escape": "3.170.0",
+        "aws-crt": "^1.13.2",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-          "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.110.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.110.0.tgz",
-          "integrity": "sha512-//pJHH7hrhdDMZGBPKXKymmC/tJM7gFT0w/qbu/yd3Wm4W2fMB+8gkmj6EZctx7jrsWlfRQuvFejKqEfapur/g==",
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.110.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.110.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.110.0.tgz",
-          "integrity": "sha512-utxxdllOnmQDhbpipnFAbuQ4c2pwefZ+2hi48jKvQRULQ2PO4nxLmdZm6B0FXaTijbKsyO7GrMik+EZ6mi3ARQ==",
-          "peer": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.55.0",
-            "@aws-sdk/types": "3.110.0",
-            "@aws-sdk/util-hex-encoding": "3.109.0",
-            "@aws-sdk/util-middleware": "3.110.0",
-            "@aws-sdk/util-uri-escape": "3.55.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.110.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
-          "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
-          "peer": true
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.109.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
-          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.55.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-          "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
-          "peer": true,
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.180.0.tgz",
+      "integrity": "sha512-3IjwOy/x6UroV3TAbeCwpCRmt/8TW89JI1r8gtDbpQ42WiQ/1J+R5a78NP8bYa53kiDghW6pKlvLcbuoh3zWHQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.178.0",
+        "@aws-sdk/signature-v4": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-arn-parser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
-      "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
+      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
-      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
+      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
-      "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
+      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
-      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.170.0.tgz",
+      "integrity": "sha512-2ivABL9GNsucfMMkgGjVdFidbDogtSr4FBVW12D4ltijOL82CAynGrnxHAczRGnmi5/1/Ir4ipkr9pAdRMGiGw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz",
+      "integrity": "sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
-      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz",
+      "integrity": "sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-      "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz",
+      "integrity": "sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-      "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz",
+      "integrity": "sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
-      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
+      "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
+      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-credentials": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
-      "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+    "@aws-sdk/util-create-request": {
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.180.0.tgz",
+      "integrity": "sha512-wBYsn+oCCNwJvltTp0hE6PzV+yZCV4orZJvpVm9AlpuXHL0NL9Xr8vMx1v9zTxG7v0aNIWIG5I/JZXwNDzkg3Q==",
       "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.178.0",
+        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
-      "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.180.0.tgz",
+      "integrity": "sha512-XGq/RUuhqnLlApETBmBWDszNG4TR3FCOSNwFvok1UIPgFXxjh0JOzNc5mAX1St2hfx1IDb9Ja4BmTkYKix7byg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
-      "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.180.0.tgz",
+      "integrity": "sha512-ch9VR4OKYGEaNbLhX/EyZDpNZst5T+/VYsFyqMA47J0YyMbg7GWyn2FjjhZ7qOV3XU6W8YEBNdd7U/LFFVp8uA==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.53.0",
-        "@aws-sdk/credential-provider-imds": "3.53.0",
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/property-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.178.0",
+        "@aws-sdk/credential-provider-imds": "3.178.0",
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/property-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.178.0.tgz",
+      "integrity": "sha512-otKBGoj4QDNdXNDUV6nTCWbAlqmrjGb6YddbwkM5lZuisLf51HE7oQnEDX6k0SRvLTq3Xk+JE7pa2RlkMfV2gQ==",
+      "requires": {
+        "@aws-sdk/querystring-builder": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
+      "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -10266,93 +10415,98 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.110.0.tgz",
-      "integrity": "sha512-PTVWrI5fA9d5hHJs6RzX2dIS2jRQ3uW073Fm0BePpQeDdZrEk+S5KNwRhUtpN6sdSV45vm6S9rrjZUG51qwGmA==",
-      "peer": true,
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
+      "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.53.0.tgz",
-      "integrity": "sha512-oh+PVTeo7nvkuXwlrAy6TErTpzTRrtxaL+2ErTFiLFPPFKK2/0X0E12zoNB0DMaY48sRdkJmrlLbOtxGDS1rNg==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.178.0.tgz",
+      "integrity": "sha512-CgXIJjDtkJPpig3/37xNzwPvtySN21m3nI/61CDjmQTFU9CfrfFplR/K3yBhB465AyINrLcDyuiBBcv78wqBzg==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/fetch-http-handler": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-base64-browser": "3.170.0",
+        "@aws-sdk/util-hex-encoding": "3.170.0",
+        "@aws-sdk/util-utf8-browser": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.53.0.tgz",
-      "integrity": "sha512-Hubb2cvn2idlNsHkJ5v46wW+cvodLySGJCqTat5kUAoOxR20ZFG3P3R6InU85PAh54zZTRvURuD0UM0uPtIQYQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.178.0.tgz",
+      "integrity": "sha512-SarpMLzoG49Tosp+s+yMsE2rGwsDqa6NDP6umqo2HXX3D26I3uqaefoB0E+Jn/VAJZcKbwxRZUPKnwQEOn1xMA==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-http-handler": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
+      "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
-      "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.178.0.tgz",
+      "integrity": "sha512-LxOrn7Ai88n0i5J5rTb5Bt0TAycPvDYzjdCwmd2mahsPHZGSDLeCeh6KOIxZsEfnzYRl4HGWvIEXdHIYZ3RTug==",
       "requires": {
-        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/types": "3.178.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
-      "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+      "version": "3.178.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.178.0.tgz",
+      "integrity": "sha512-TrP6v+V4Qnv3E9CNgwR/G+1xiy8fa9j5LAm43qwp9PfJHchNyWOJ0FURD3Ne2sm/388Ybzjb1DRYRZ7B+xbnOw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
-      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
+      "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
-      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
+      "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.170.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
-      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
+      "version": "3.180.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.180.0.tgz",
+      "integrity": "sha512-fDBGplYp6pIIfrB7073tUhU4zppRaSiPjBCCT00yth9woWwZPUCIg7iQZKEqkBmvCzcJSYn0jRopLhf3Y7i5Wg==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.53.0",
-        "@aws-sdk/types": "3.53.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.178.0",
+        "@aws-sdk/types": "3.178.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
-      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "version": "3.170.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.170.0.tgz",
+      "integrity": "sha512-eN458rrukeI62yU1k4a+032IfpAS7aK30VEITzKanklMW6AxTpxUC6vGrP6bwtIpCFDN8yVaIiAwGXQg5l1X4g==",
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -11033,6 +11187,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.1.tgz",
       "integrity": "sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==",
+      "optional": true,
       "peer": true,
       "requires": {
         "@types/ws": "*",
@@ -11049,6 +11204,7 @@
           "version": "3.7.1",
           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
           "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "optional": true,
           "peer": true,
           "requires": {
             "end-of-stream": "^1.0.0",
@@ -11061,6 +11217,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11076,12 +11233,14 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true,
           "peer": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -11600,7 +11759,8 @@
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "devOptional": true
     },
     "@types/pg": {
       "version": "8.6.4",
@@ -11641,6 +11801,7 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
       "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
       "peer": true,
       "requires": {
         "@types/node": "*"
@@ -11824,6 +11985,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
+      "optional": true,
       "peer": true
     },
     "ansi-escapes": {
@@ -11870,6 +12032,52 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
+    "are-we-there-yet": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true,
+          "peer": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -11890,8 +12098,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -11909,28 +12116,40 @@
       }
     },
     "aws-crt": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.12.4.tgz",
-      "integrity": "sha512-BqvCb016EHVQV7P50x8VyqB5cgYrsFOEZoZdCaBrGc/cZTGRrFQOfbpPbuivgRHg55e7b1cFkgXDG88jdmOURw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.14.4.tgz",
+      "integrity": "sha512-ZAjZ4sg4GVN4W/P3r6CgcMcY4qp9gGuRxi5e/vSbNX6eI5wte2jN9i6HgPrmoRLiXbmt9b6CLF4lc91U1O7snA==",
+      "optional": true,
       "peer": true,
       "requires": {
+        "@aws-sdk/util-utf8-browser": "^3.109.0",
         "@httptoolkit/websocket-stream": "^6.0.0",
         "axios": "^0.24.0",
-        "cmake-js": "6.3.0",
+        "cmake-js": "^6.3.2",
         "crypto-js": "^4.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.3.4",
-        "tar": "^6.1.11",
-        "ws": "^7.5.5"
+        "mqtt": "^4.3.7",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
       }
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "peer": true,
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "babel-jest": {
@@ -12035,6 +12254,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "buffers": "~0.1.1",
@@ -12056,6 +12276,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "optional": true,
       "peer": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -12064,9 +12285,10 @@
       }
     },
     "bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "optional": true,
       "peer": true
     },
     "bowser": {
@@ -12078,6 +12300,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -12139,18 +12362,21 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "devOptional": true
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
       "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "optional": true,
       "peer": true
     },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
+      "optional": true,
       "peer": true
     },
     "buffer-writer": {
@@ -12162,6 +12388,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "optional": true,
       "peer": true
     },
     "callsites": {
@@ -12186,6 +12413,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "optional": true,
       "peer": true,
       "requires": {
         "traverse": ">=0.3.0 <0.4"
@@ -12250,9 +12478,10 @@
       }
     },
     "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "optional": true,
       "peer": true
     },
     "ci-info": {
@@ -12279,12 +12508,14 @@
       }
     },
     "cmake-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
-      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.2.tgz",
+      "integrity": "sha512-7MfiQ/ijzeE2kO+WFB9bv4QP5Dn2yVaAP2acFJr4NIFy2hT4w6O4EpOTLNcohR5IPX7M4wNf/5taIqMj7UA9ug==",
+      "optional": true,
       "peer": true,
       "requires": {
         "axios": "^0.21.1",
+        "bluebird": "^3",
         "debug": "^4",
         "fs-extra": "^5.0.0",
         "is-iojs": "^1.0.1",
@@ -12305,22 +12536,14 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "optional": true,
           "peer": true
-        },
-        "are-we-there-yet": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-          "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
-          "peer": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.0 || ^1.1.13"
-          }
         },
         "axios": {
           "version": "0.21.4",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
           "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "follow-redirects": "^1.14.0"
@@ -12330,12 +12553,21 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
+          "optional": true,
+          "peer": true
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "optional": true,
           "peer": true
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+          "optional": true,
           "peer": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -12347,6 +12579,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "optional": true,
           "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -12358,28 +12591,17 @@
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "optional": true,
           "peer": true,
           "requires": {
             "minipass": "^2.6.0"
-          }
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
-          "peer": true,
-          "requires": {
-            "ansi": "^0.3.0",
-            "has-unicode": "^2.0.0",
-            "lodash.pad": "^4.1.0",
-            "lodash.padend": "^4.1.0",
-            "lodash.padstart": "^4.1.0"
           }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -12389,6 +12611,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -12398,6 +12621,7 @@
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -12408,6 +12632,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
           "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "optional": true,
           "peer": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -12417,72 +12642,24 @@
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "minimist": "^1.2.6"
-          }
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-          "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
-          "peer": true,
-          "requires": {
-            "ansi": "~0.3.0",
-            "are-we-there-yet": "~1.0.0",
-            "gauge": "~1.2.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "peer": true
-            }
           }
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "optional": true,
           "peer": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "peer": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "peer": true
-            }
-          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -12494,6 +12671,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -12503,6 +12681,7 @@
           "version": "4.4.19",
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
           "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+          "optional": true,
           "peer": true,
           "requires": {
             "chownr": "^1.1.4",
@@ -12518,12 +12697,14 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "optional": true,
           "peer": true
         },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "optional": true,
           "peer": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -12533,6 +12714,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -12543,18 +12725,21 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
           "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+          "optional": true,
           "peer": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "optional": true,
           "peer": true
         },
         "yargs": {
           "version": "3.32.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "camelcase": "^2.0.1",
@@ -12577,7 +12762,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "optional": true,
       "peer": true
     },
     "collect-v8-coverage": {
@@ -12605,7 +12791,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -12619,6 +12804,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
       "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "leven": "^2.1.0",
@@ -12628,12 +12814,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "devOptional": true
     },
     "concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
       "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "optional": true,
       "peer": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -12676,6 +12864,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "optional": true,
       "peer": true
     },
     "create-require": {
@@ -12726,6 +12915,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "optional": true,
       "peer": true
     },
     "decimal.js": {
@@ -12743,6 +12933,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true,
       "peer": true
     },
     "deep-is": {
@@ -12759,13 +12950,13 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "optional": true,
       "peer": true
     },
     "detect-newline": {
@@ -12813,6 +13004,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "optional": true,
       "peer": true,
       "requires": {
         "readable-stream": "^2.0.2"
@@ -12822,6 +13014,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -12837,12 +13030,14 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true,
           "peer": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -13290,12 +13485,6 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "peer": true
-    },
     "fastify": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.2.1.tgz",
@@ -13454,7 +13643,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13485,6 +13673,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -13511,6 +13700,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -13523,6 +13713,7 @@
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
           "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "minimist": "^1.2.6"
@@ -13532,6 +13723,7 @@
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
           "peer": true,
           "requires": {
             "glob": "^7.1.3"
@@ -13549,6 +13741,20 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -13583,6 +13789,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "devOptional": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13646,13 +13853,15 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "optional": true,
       "peer": true
     },
     "help-me": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
       "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "optional": true,
       "peer": true,
       "requires": {
         "glob": "^7.1.6",
@@ -13731,6 +13940,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true,
       "peer": true
     },
     "interpret": {
@@ -13742,6 +13952,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
+      "optional": true,
       "peer": true
     },
     "ipaddr.js": {
@@ -13803,6 +14014,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
       "integrity": "sha512-tLn1j3wYSL6DkvEI+V/j0pKohpa5jk+ER74v6S4SgCXnjS0WA+DoZbwZBrrhgwksMvtuwndyGeG5F8YMsoBzSA==",
+      "optional": true,
       "peer": true
     },
     "is-number": {
@@ -13820,18 +14032,21 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "optional": true,
       "peer": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "devOptional": true
     },
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "optional": true,
       "peer": true,
       "requires": {}
     },
@@ -14345,9 +14560,10 @@
       "dev": true
     },
     "js-sdsl": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
-      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "optional": true,
       "peer": true
     },
     "js-tokens": {
@@ -14517,6 +14733,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+      "optional": true,
       "peer": true,
       "requires": {
         "invert-kv": "^1.0.0"
@@ -14525,7 +14742,8 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "optional": true,
       "peer": true
     },
     "levn": {
@@ -14565,6 +14783,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "optional": true,
       "peer": true
     },
     "locate-path": {
@@ -14632,18 +14851,21 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
       "integrity": "sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg==",
+      "optional": true,
       "peer": true
     },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
+      "optional": true,
       "peer": true
     },
     "lodash.padstart": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
+      "optional": true,
       "peer": true
     },
     "logflare-transport-core": {
@@ -14713,6 +14935,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
       "integrity": "sha512-q0D3m846qY6ZkIt+19ZemU5vH56lpOZZwoJc3AICARKh/menBuayQUjAGPrqtHQQMUYERSdOrej92J9kz7LgYA==",
+      "optional": true,
       "peer": true,
       "requires": {
         "readable-stream": "~1.0.26-2"
@@ -14722,12 +14945,14 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "optional": true,
           "peer": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -14740,6 +14965,7 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "optional": true,
           "peer": true
         }
       }
@@ -14774,14 +15000,12 @@
     "mime-db": {
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
-      "dev": true
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
       "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.46.0"
       }
@@ -14796,6 +15020,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -14803,12 +15028,14 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "devOptional": true
     },
     "minipass": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
-      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
+      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
+      "optional": true,
       "peer": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -14818,6 +15045,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "minipass": "^3.0.0",
@@ -14827,12 +15055,14 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "devOptional": true
     },
     "mqtt": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
       "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+      "optional": true,
       "peer": true,
       "requires": {
         "commist": "^1.0.0",
@@ -14858,10 +15088,19 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
           "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "optional": true,
           "peer": true,
           "requires": {
             "readable-stream": "^3.0.0"
           }
+        },
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "optional": true,
+          "peer": true,
+          "requires": {}
         }
       }
     },
@@ -14869,6 +15108,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
       "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "optional": true,
       "peer": true,
       "requires": {
         "bl": "^4.0.2",
@@ -14943,20 +15183,34 @@
         "path-key": "^3.0.0"
       }
     },
+    "npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "ansi": "~0.3.0",
+        "are-we-there-yet": "~1.0.0",
+        "gauge": "~1.2.0"
+      }
+    },
     "number-allocator": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
-      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.12.tgz",
+      "integrity": "sha512-sGB0qoQGmKimery9JubBQ9pQUr1V/LixJAk3Ygp7obZf6mpSXime8d7XHEobbIimkdZpgjkNlLt6G7LPEWFYWg==",
+      "optional": true,
       "peer": true,
       "requires": {
         "debug": "^4.3.1",
-        "js-sdsl": "^2.1.2"
+        "js-sdsl": "4.1.4"
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "optional": true,
       "peer": true
     },
     "on-exit-leak-free": {
@@ -14999,6 +15253,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
+      "optional": true,
       "peer": true,
       "requires": {
         "lcid": "^1.0.0"
@@ -15073,7 +15328,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "devOptional": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -15475,6 +15731,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "optional": true,
       "peer": true
     },
     "process-warning": {
@@ -15553,6 +15810,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "peer": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -15564,7 +15822,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+          "optional": true,
           "peer": true
         }
       }
@@ -15617,6 +15876,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
       "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "optional": true,
       "peer": true
     },
     "require-directory": {
@@ -15742,6 +16002,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "optional": true,
       "peer": true
     },
     "setprototypeof": {
@@ -15815,6 +16076,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
       "integrity": "sha512-UUFYD2oWbNwULH6WoVtLUOw8ch586B+HUqcsAjjjeoBQAM1bD4wZRXu01koaxyd8UeYpybWqW4h+lO1Okv40Tg==",
+      "optional": true,
       "peer": true
     },
     "sprintf-js": {
@@ -15940,6 +16202,7 @@
       "version": "6.1.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "optional": true,
       "peer": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -15948,14 +16211,6 @@
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "peer": true
-        }
       }
     },
     "tarn": {
@@ -16060,6 +16315,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "optional": true,
       "peer": true
     },
     "tree-kill": {
@@ -16220,6 +16476,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "optional": true,
       "peer": true
     },
     "typescript": {
@@ -16237,6 +16494,7 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
       "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "optional": true,
       "peer": true,
       "requires": {
         "big-integer": "^1.6.17",
@@ -16250,16 +16508,25 @@
         "setimmediate": "~1.0.4"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+          "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+          "optional": true,
+          "peer": true
+        },
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
+          "optional": true,
           "peer": true
         },
         "readable-stream": {
           "version": "2.1.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
+          "optional": true,
           "peer": true,
           "requires": {
             "buffer-shims": "^1.0.0",
@@ -16275,6 +16542,7 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "optional": true,
           "peer": true
         }
       }
@@ -16301,6 +16569,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
       "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
+      "optional": true,
       "peer": true
     },
     "util-deprecate": {
@@ -16357,6 +16626,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
+      "optional": true,
       "peer": true
     },
     "word-wrap": {
@@ -16418,9 +16688,10 @@
       }
     },
     "ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "optional": true,
       "peer": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.53.0",
-    "@aws-sdk/lib-storage": "^3.53.0",
-    "@aws-sdk/node-http-handler": "^3.53.0",
+    "@aws-sdk/client-s3": "^3.181.0",
+    "@aws-sdk/lib-storage": "^3.182.0",
+    "@aws-sdk/node-http-handler": "^3.178.0",
+    "@aws-sdk/s3-request-presigner": "^3.182.0",
     "@fastify/multipart": "^7.1.0",
     "@fastify/swagger": "^7.4.1",
     "@supabase/postgrest-js": "^0.36.0",
+    "axios": "^0.27.2",
     "crypto-js": "^4.1.1",
     "dotenv": "^16.0.0",
     "fastify": "^4.2.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import fastifyMultipart from '@fastify/multipart'
 import fastifySwagger from '@fastify/swagger'
 import bucketRoutes from './routes/bucket/'
 import objectRoutes from './routes/object'
+import renderRoutes from './routes/render'
 import { authSchema } from './schemas/auth'
 import { errorSchema } from './schemas/error'
 import logTenantId from './plugins/log-tenant-id'
@@ -57,6 +58,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(logRequest({ excludeUrls: ['/status'] }))
   app.register(bucketRoutes, { prefix: 'bucket' })
   app.register(objectRoutes, { prefix: 'object' })
+  app.register(renderRoutes, { prefix: 'render' })
 
   app.get('/status', async (request, response) => response.status(200).send())
 

--- a/src/backend/file.ts
+++ b/src/backend/file.ts
@@ -106,4 +106,8 @@ export class FileBackend implements GenericStorageBackend {
       size: data.size,
     }
   }
+
+  async privateAssetUrl(bucket: string, key: string): Promise<string> {
+    return 'local:///' + path.join(this.filePath, `${bucket}/${key}`)
+  }
 }

--- a/src/backend/generic.ts
+++ b/src/backend/generic.ts
@@ -39,4 +39,7 @@ export abstract class GenericStorageBackend {
   async headObject(bucket: string, key: string): Promise<ObjectMetadata> {
     throw new Error('headObject not implemented')
   }
+  async privateAssetUrl(bucket: string, key: string): Promise<string> {
+    throw new Error('privateAssetUrl not implemented')
+  }
 }

--- a/src/backend/s3.ts
+++ b/src/backend/s3.ts
@@ -14,6 +14,7 @@ import { NodeHttpHandler } from '@aws-sdk/node-http-handler'
 import { ObjectMetadata, ObjectResponse } from '../types/types'
 import { GenericStorageBackend, GetObjectHeaders } from './generic'
 import { convertErrorToStorageBackendError } from '../utils/errors'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
 export class S3Backend implements GenericStorageBackend {
   client: S3Client
@@ -142,5 +143,15 @@ export class S3Backend implements GenericStorageBackend {
       httpStatusCode: data.$metadata.httpStatusCode,
       size: data.ContentLength,
     }
+  }
+
+  async privateAssetUrl(bucket: string, key: string): Promise<string> {
+    const input: GetObjectCommandInput = {
+      Bucket: bucket,
+      Key: key,
+    }
+
+    const command = new GetObjectCommand(input)
+    return getSignedUrl(this.client, command, { expiresIn: 3600 })
   }
 }

--- a/src/renderer/imgproxy.ts
+++ b/src/renderer/imgproxy.ts
@@ -1,0 +1,75 @@
+import { GenericStorageBackend } from '../backend/generic'
+import axios, { Axios } from 'axios'
+import { getConfig } from '../utils/config'
+
+interface TransformOptions {
+  width?: number
+  height?: number
+  resize?: 'fill' | 'fit' | 'fill-down' | 'force' | 'auto'
+}
+
+interface ImgProxyOptions {
+  url: string
+}
+
+const { imgLimits } = getConfig()
+
+const LIMITS = {
+  height: {
+    min: imgLimits.size.min,
+    max: imgLimits.size.max,
+  },
+  width: {
+    min: imgLimits.size.min,
+    max: imgLimits.size.max,
+  },
+}
+
+export class Imgproxy {
+  private client: Axios
+
+  constructor(
+    private readonly backend: GenericStorageBackend,
+    private readonly options: ImgProxyOptions
+  ) {
+    this.client = axios.create({
+      baseURL: options.url,
+      timeout: 8000,
+    })
+  }
+
+  getClient() {
+    return this.client
+  }
+
+  async transform(bucket: string, key: string, options: TransformOptions) {
+    const privateURL = await this.backend.privateAssetUrl(bucket, key)
+    const urlTransformation = this.applyURLTransformation(options)
+
+    const url = ['/public', ...urlTransformation, 'plain', privateURL]
+
+    return this.getClient().get(url.join('/'), {
+      responseType: 'stream',
+    })
+  }
+
+  protected applyURLTransformation(options: TransformOptions) {
+    const segments = []
+
+    if (options.height) {
+      segments.push(`height:${clamp(options.height, LIMITS.height.min, LIMITS.height.max)}`)
+    }
+
+    if (options.width) {
+      segments.push(`width:${clamp(options.width, LIMITS.width.min, LIMITS.width.max)}`)
+    }
+
+    if (options.width || options.height) {
+      segments.push(`resizing_type:${options.resize || 'fill'}`)
+    }
+
+    return segments
+  }
+}
+
+const clamp = (num: number, min: number, max: number) => Math.min(Math.max(num, min), max)

--- a/src/routes/render/index.ts
+++ b/src/routes/render/index.ts
@@ -1,0 +1,20 @@
+import { FastifyInstance } from 'fastify'
+import { postgrest, superUserPostgrest } from '../../plugins/postgrest'
+import renderPublicImage from './renderPublicImage'
+import renderAuthenticatedImage from './renderAuthenticatedImage'
+import jwt from '../../plugins/jwt'
+
+export default async function routes(fastify: FastifyInstance) {
+  fastify.register(async function authorizationContext(fastify) {
+    fastify.register(jwt)
+    fastify.register(postgrest)
+
+    fastify.register(renderAuthenticatedImage)
+  })
+
+  fastify.register(async (fastify) => {
+    fastify.register(superUserPostgrest)
+
+    fastify.register(renderPublicImage)
+  })
+}

--- a/src/routes/render/renderAuthenticatedImage.ts
+++ b/src/routes/render/renderAuthenticatedImage.ts
@@ -1,0 +1,111 @@
+import { getConfig } from '../../utils/config'
+import { GenericStorageBackend } from '../../backend/generic'
+import { FileBackend } from '../../backend/file'
+import { S3Backend } from '../../backend/s3'
+import { FromSchema } from 'json-schema-to-ts'
+import { FastifyInstance } from 'fastify'
+import { Obj } from '../../types/types'
+import { normalizeContentType, transformPostgrestError } from '../../utils'
+import { Imgproxy } from '../../renderer/imgproxy'
+import { AxiosError } from 'axios'
+
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, imgProxyURL } = getConfig()
+
+let storageBackend: GenericStorageBackend
+
+if (storageBackendType === 'file') {
+  storageBackend = new FileBackend()
+} else {
+  storageBackend = new S3Backend(region, globalS3Endpoint)
+}
+
+const imageRenderer = new Imgproxy(storageBackend, {
+  url: imgProxyURL || '',
+})
+
+const renderAuthenticatedImageParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+
+const renderImageQuerySchema = {
+  type: 'object',
+  properties: {
+    height: { type: 'number', examples: [100] },
+    width: { type: 'number', examples: [100] },
+    resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+  },
+} as const
+
+interface renderImageRequestInterface {
+  Params: FromSchema<typeof renderAuthenticatedImageParamsSchema>
+  Querystring: FromSchema<typeof renderImageQuerySchema>
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Render an authenticated image with the given transformations'
+  fastify.get<renderImageRequestInterface>(
+    '/authenticated/:bucketName/*',
+    {
+      schema: {
+        params: renderAuthenticatedImageParamsSchema,
+        summary,
+        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        tags: ['object'],
+      },
+    },
+    async (request, response) => {
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+
+      const objectResponse = await request.postgrest
+        .from<Obj>('objects')
+        .select('id')
+        .match({
+          name: objectName,
+          bucket_id: bucketName,
+        })
+        .single()
+
+      if (objectResponse.error) {
+        const { status, error } = objectResponse
+        request.log.error({ error }, 'error object')
+        return response.status(400).send(transformPostgrestError(error, status))
+      }
+
+      const s3Key = `${request.tenantId}/${bucketName}/${objectName}`
+
+      try {
+        const imageResponse = await imageRenderer.transform(globalS3Bucket, s3Key, request.query)
+
+        response
+          .status(imageResponse.status)
+          .header('Accept-Ranges', 'bytes')
+          .header('Content-Type', normalizeContentType(imageResponse.headers['content-type']))
+          .header('Cache-Control', imageResponse.headers['cache-control'])
+          .header('Content-Length', imageResponse.headers['content-length'])
+          .header('ETag', imageResponse.headers['etag'])
+
+        return response.send(imageResponse.data)
+      } catch (err: any) {
+        if (err.response) {
+          return response.status(err.response?.status || 500).send({
+            message: err.message,
+            statusCode: err.response?.status || '500',
+            error: err.message,
+          })
+        }
+
+        return response.status(500).send({
+          message: err.message,
+          statusCode: '500',
+          error: err.message,
+        })
+      }
+    }
+  )
+}

--- a/src/routes/render/renderPublicImage.ts
+++ b/src/routes/render/renderPublicImage.ts
@@ -1,0 +1,108 @@
+import { getConfig } from '../../utils/config'
+import { GenericStorageBackend } from '../../backend/generic'
+import { FileBackend } from '../../backend/file'
+import { S3Backend } from '../../backend/s3'
+import { FromSchema } from 'json-schema-to-ts'
+import { FastifyInstance } from 'fastify'
+import { Bucket } from '../../types/types'
+import { normalizeContentType, transformPostgrestError } from '../../utils'
+import { Imgproxy } from '../../renderer/imgproxy'
+import { AxiosError } from 'axios'
+
+const { region, globalS3Bucket, globalS3Endpoint, storageBackendType, imgProxyURL } = getConfig()
+
+let storageBackend: GenericStorageBackend
+
+if (storageBackendType === 'file') {
+  storageBackend = new FileBackend()
+} else {
+  storageBackend = new S3Backend(region, globalS3Endpoint)
+}
+
+const imageRenderer = new Imgproxy(storageBackend, {
+  url: imgProxyURL || '',
+})
+
+const renderPublicImageParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+
+const renderImageQuerySchema = {
+  type: 'object',
+  properties: {
+    height: { type: 'number', examples: [100] },
+    width: { type: 'number', examples: [100] },
+    resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+  },
+} as const
+
+interface renderImageRequestInterface {
+  Params: FromSchema<typeof renderPublicImageParamsSchema>
+  Querystring: FromSchema<typeof renderImageQuerySchema>
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Render a public image with the given transformations'
+  fastify.get<renderImageRequestInterface>(
+    '/public/:bucketName/*',
+    {
+      schema: {
+        params: renderPublicImageParamsSchema,
+        summary,
+        response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
+        tags: ['object'],
+      },
+    },
+    async (request, response) => {
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+
+      const { error, status } = await request.superUserPostgrest
+        .from<Bucket>('buckets')
+        .select('id, public')
+        .eq('id', bucketName)
+        .eq('public', true)
+        .single()
+
+      if (error) {
+        request.log.error({ error }, 'error finding public bucket')
+        return response.status(400).send(transformPostgrestError(error, status))
+      }
+
+      const s3Key = `${request.tenantId}/${bucketName}/${objectName}`
+
+      try {
+        const imageResponse = await imageRenderer.transform(globalS3Bucket, s3Key, request.query)
+
+        response
+          .status(imageResponse.status)
+          .header('Accept-Ranges', 'bytes')
+          .header('Content-Type', normalizeContentType(imageResponse.headers['content-type']))
+          .header('Cache-Control', imageResponse.headers['cache-control'])
+          .header('Content-Length', imageResponse.headers['content-length'])
+          .header('ETag', imageResponse.headers['etag'])
+
+        return response.send(imageResponse.data)
+      } catch (err: any) {
+        if (err.response) {
+          return response.status(err.response?.status || 500).send({
+            message: err.message,
+            statusCode: err.response?.status || '500',
+            error: err.message,
+          })
+        }
+
+        return response.status(500).send({
+          message: err.message,
+          statusCode: '500',
+          error: err.message,
+        })
+      }
+    }
+  )
+}

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -95,7 +95,7 @@ describe('testing GET all buckets', () => {
     })
     expect(response.statusCode).toBe(200)
     const responseJSON = JSON.parse(response.body)
-    expect(responseJSON.length).toBe(5)
+    expect(responseJSON.length).toBe(6)
   })
 
   test('checking RLS: anon user is not able to get all buckets', async () => {

--- a/src/test/db/04-dummy-data.sql.sample
+++ b/src/test/db/04-dummy-data.sql.sample
@@ -5,12 +5,13 @@ INSERT INTO "auth"."users" ("instance_id", "id", "aud", "role", "email", "encryp
 ('00000000-0000-0000-0000-000000000000', 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2', 'authenticated', 'authenticated', 'inian+admin@supabase.io', '', NULL, '2021-02-17 04:40:42.901743+00', '3EG99GjT_e3NC4eGEBXOjw', '2021-02-17 04:40:42.901743+00', '', NULL, '', '', NULL, NULL, '{"provider": "email"}', 'null', 'f', '2021-02-17 04:40:42.890632+00', '2021-02-17 04:40:42.890637+00');
 
 -- insert buckets
-INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at") VALUES
-('bucket2', 'bucket2', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00'),
-('bucket3', 'bucket3', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00'),
-('bucket4', 'bucket4', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-25 09:23:01.58385+00', '2021-02-25 09:23:01.58385+00'),
-('bucket5', 'bucket5', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00'),
-('public-bucket', 'public-bucket', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00');
+INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public") VALUES
+('bucket2', 'bucket2', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false),
+('bucket3', 'bucket3', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false),
+('bucket4', 'bucket4', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-25 09:23:01.58385+00', '2021-02-25 09:23:01.58385+00', false),
+('bucket5', 'bucket5', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', false),
+('public-bucket', 'public-bucket', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true),
+('public-bucket-2', 'public-bucket-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true);
 
 
 -- insert objects
@@ -35,7 +36,8 @@ INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at
 ('b39ae4ab-802b-4c42-9271-3f908c34363c', 'bucket2', 'private/sadcat-upload3.png', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}'),
 ('8098E1AC-C744-4368-86DF-71B60CCDE221', 'bucket3', 'sadcat-upload3.png', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}'),
 ('D3EB488E-94F4-46CD-86D3-242C13B95BAC', 'bucket3', 'sadcat-upload2.png', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}'),
-('746180e8-8029-4134-8a21-48ab35485d81', 'public-bucket', 'favicon.ico', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}');
+('746180e8-8029-4134-8a21-48ab35485d81', 'public-bucket', 'favicon.ico', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}'),
+('ea2e2806-9ded-4882-8c26-e172a29ed063', 'public-bucket-2', 'favicon.ico', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '2021-03-01 08:53:29.567975+00', '{"mimetype": "image/svg+xml", "size": 1234}');
 ;
 INSERT INTO "storage"."objects" ("id", "bucket_id", "name", "owner", "created_at", "updated_at", "last_accessed_at", "metadata")
 SELECT gen_random_uuid(), 'bucket2', 'authenticated/' || i, '317eadce-631a-4429-a0bb-f19a7a517b4a', now(), now(), now(), '{"size": 1234}'

--- a/src/test/db/docker-compose.yml
+++ b/src/test/db/docker-compose.yml
@@ -33,3 +33,13 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+
+  imgproxy:
+    image: darthsim/imgproxy
+    ports:
+      - 50020:8080
+    volumes:
+      - ./data:/images/data
+    environment:
+      - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/images
+      - IMGPROXY_USE_ETAG=true

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -1,0 +1,103 @@
+import dotenv from 'dotenv'
+import fs from 'fs/promises'
+import { getConfig } from '../utils/config'
+import app from '../app'
+import { S3Backend } from '../backend/s3'
+import path from 'path'
+import { Imgproxy } from '../renderer/imgproxy'
+import axios from 'axios'
+
+dotenv.config({ path: '.env.test' })
+const ENV = process.env
+const { imgProxyURL } = getConfig()
+
+describe('image rendering routes', () => {
+  beforeAll(async () => {
+    await fs.mkdir(path.join(__dirname, '..', '..', 'data'), { recursive: true })
+    await fs.copyFile(
+      path.resolve(__dirname, 'assets', 'sadcat.jpg'),
+      path.join(__dirname, '..', '..', 'data', 'sadcat.jpg')
+    )
+  })
+  beforeEach(() => {
+    process.env = { ...ENV }
+
+    jest.spyOn(S3Backend.prototype, 'getObject').mockResolvedValue({
+      metadata: {
+        httpStatusCode: 200,
+        size: 3746,
+        mimetype: 'image/png',
+        lastModified: new Date('Thu, 12 Aug 2021 16:00:00 GMT'),
+        eTag: 'abc',
+      },
+      body: Buffer.from(''),
+    })
+
+    jest.spyOn(S3Backend.prototype, 'uploadObject').mockResolvedValue({
+      httpStatusCode: 200,
+      size: 3746,
+      mimetype: 'image/png',
+    })
+
+    jest.spyOn(S3Backend.prototype, 'copyObject').mockResolvedValue({
+      httpStatusCode: 200,
+      size: 3746,
+      mimetype: 'image/png',
+    })
+
+    jest.spyOn(S3Backend.prototype, 'deleteObject').mockResolvedValue({})
+
+    jest.spyOn(S3Backend.prototype, 'deleteObjects').mockResolvedValue({})
+
+    jest.spyOn(S3Backend.prototype, 'headObject').mockResolvedValue({
+      httpStatusCode: 200,
+      size: 3746,
+      mimetype: 'image/png',
+    })
+
+    jest.spyOn(S3Backend.prototype, 'privateAssetUrl').mockResolvedValue('local:///data/sadcat.jpg')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('will render an authenticated image applying transformations using external image processing', async () => {
+    const testAxios = axios.create({ baseURL: imgProxyURL })
+    jest.spyOn(Imgproxy.prototype, 'getClient').mockReturnValue(testAxios)
+    const axiosSpy = jest.spyOn(testAxios, 'get')
+
+    const response = await app().inject({
+      method: 'GET',
+      url: '/render/authenticated/bucket2/authenticated/casestudy.png?width=100&height=100',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
+    expect(axiosSpy).toBeCalledWith(
+      '/public/height:100/width:100/resizing_type:fill/plain/local:///data/sadcat.jpg',
+      { responseType: 'stream' }
+    )
+  })
+
+  it('will render a public image applying transformations using external image processing', async () => {
+    const testAxios = axios.create({ baseURL: imgProxyURL })
+    jest.spyOn(Imgproxy.prototype, 'getClient').mockReturnValue(testAxios)
+    const axiosSpy = jest.spyOn(testAxios, 'get')
+
+    const response = await app().inject({
+      method: 'GET',
+      url: '/render/public/public-bucket-2/favicon.ico?width=100&height=100',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.privateAssetUrl).toBeCalledTimes(1)
+    expect(axiosSpy).toBeCalledWith(
+      '/public/height:100/width:100/resizing_type:fill/plain/local:///data/sadcat.jpg',
+      { responseType: 'stream' }
+    )
+  })
+})

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,6 +27,13 @@ type StorageConfigType = {
   logflareEnabled?: boolean
   logflareApiKey?: string
   logflareSourceToken?: string
+  imgProxyURL?: string
+  imgLimits: {
+    size: {
+      min: number
+      max: number
+    }
+  }
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -79,5 +86,12 @@ export function getConfig(): StorageConfigType {
     logflareEnabled: getOptionalConfigFromEnv('LOGFLARE_ENABLED') === 'true',
     logflareApiKey: getOptionalConfigFromEnv('LOGFLARE_API_KEY'),
     logflareSourceToken: getOptionalConfigFromEnv('LOGFLARE_SOURCE_TOKEN'),
+    imgProxyURL: getOptionalConfigFromEnv('IMGPROXY_URL'),
+    imgLimits: {
+      size: {
+        min: parseInt(getOptionalConfigFromEnv('IMG_LIMITS_MIN_SIZE') || '1', 10),
+        max: parseInt(getOptionalConfigFromEnv('IMG_LIMITS_MAX_SIZE') || '5000', 10),
+      },
+    },
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently is not possible to do image transformations on the fly

## What is the new behavior?

With this PR `storage-api` will be able to offload image processing to imgproxy and return the transformed image.

2 New endpoints have been introduced:

- `/storage/v1/render/public/<bucket>/<key>`
- `/storage/v1/render/authenticated/<bucket>/<key>`

Currently supported processing options:

- `width`
- `height`
- `resize` 
