### PR TITLE
fix: returns 404 on public object not found in the DB

### DIFF
--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -141,6 +141,22 @@ describe('testing GET object', () => {
     expect(S3Backend.prototype.headObject).toBeCalled()
   })
 
+  test('returns 404 for non exising public', async () => {
+    const response = await app().inject({
+      method: 'GET',
+      url: '/object/public/public-bucket-2/not-existing.ico',
+      headers: {
+        authorization: ``,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      statusCode: '404',
+      error: 'Not found',
+      message: 'The resource was not found',
+    })
+  })
+
   test('force downloading file with default name', async () => {
     const response = await app().inject({
       method: 'GET',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

At the moment we would send a request to S3 when looking up public object and rely on s3 status code as our response to clients

## What is the new behavior?

This PR will verify the existence of the object in the DB before going to S3
