### PR TITLE
Feat/use environment variables with default values

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,8 @@ type StorageConfigType = {
     }
   }
   postgrestForwardHeaders?: string
+  port?: number;
+  host?: string;
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -97,5 +99,7 @@ export function getConfig(): StorageConfigType {
       },
     },
     postgrestForwardHeaders: getOptionalConfigFromEnv('POSTGREST_FORWARD_HEADERS'),
+    host: getOptionalConfigFromEnv('HOST') || '0.0.0.0',
+    port: Number(getOptionalConfigFromEnv('PORT')) || 5000
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,8 +36,9 @@ type StorageConfigType = {
     }
   }
   postgrestForwardHeaders?: string
-  port?: number;
-  host?: string;
+  adminPort: number;
+  port: number;
+  host: string;
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -100,6 +101,7 @@ export function getConfig(): StorageConfigType {
     },
     postgrestForwardHeaders: getOptionalConfigFromEnv('POSTGREST_FORWARD_HEADERS'),
     host: getOptionalConfigFromEnv('HOST') || '0.0.0.0',
-    port: Number(getOptionalConfigFromEnv('PORT')) || 5000
+    port: Number(getOptionalConfigFromEnv('PORT')) || 5000,
+    adminPort: Number(getOptionalConfigFromEnv('ADMIN_PORT')) || 5001
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,9 @@ import { logger } from './monitoring'
 
 const exposeDocs = true
 
+const port = process.env.PORT || 5000;
+const host = process.env.HOST || '0.0.0.0'
+
 ;(async () => {
   const { isMultitenant, requestIdHeader, adminRequestIdHeader } = getConfig()
   if (isMultitenant) {
@@ -23,7 +26,7 @@ const exposeDocs = true
     })
 
     try {
-      await adminApp.listen({ port: 5001, host: '0.0.0.0' })
+      await adminApp.listen({ port, host })
     } catch (err) {
       adminApp.log.error(err)
       process.exit(1)
@@ -41,8 +44,8 @@ const exposeDocs = true
 
   app.listen(
     {
-      port: 5000,
-      host: '0.0.0.0',
+      port,
+      host,
     },
     (err, address) => {
       if (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { logger } from './monitoring'
 
 const exposeDocs = true
 
-const port = process.env.PORT || 5000;
+const port = Number(process.env.PORT) || 5000;
 const host = process.env.HOST || '0.0.0.0'
 
 ;(async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { logger } from './monitoring'
 const exposeDocs = true
 
 ;(async () => {
-  const { isMultitenant, requestIdHeader, adminRequestIdHeader, port, host } = getConfig()
+  const { isMultitenant, requestIdHeader, adminRequestIdHeader, adminPort, port, host } = getConfig()
   if (isMultitenant) {
     await runMultitenantMigrations()
     await listenForTenantUpdate()
@@ -23,7 +23,7 @@ const exposeDocs = true
     })
 
     try {
-      await adminApp.listen({ port, host })
+      await adminApp.listen({ port: adminPort, host })
     } catch (err) {
       adminApp.log.error(err)
       process.exit(1)
@@ -39,11 +39,7 @@ const exposeDocs = true
     requestIdHeader,
   })
 
-  app.listen(
-    {
-      port,
-      host,
-    },
+  app.listen({ port, host },
     (err, address) => {
       if (err) {
         console.error(err)

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,11 +10,8 @@ import { logger } from './monitoring'
 
 const exposeDocs = true
 
-const port = Number(process.env.PORT) || 5000;
-const host = process.env.HOST as string || '0.0.0.0'
-
 ;(async () => {
-  const { isMultitenant, requestIdHeader, adminRequestIdHeader } = getConfig()
+  const { isMultitenant, requestIdHeader, adminRequestIdHeader, port, host } = getConfig()
   if (isMultitenant) {
     await runMultitenantMigrations()
     await listenForTenantUpdate()

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { logger } from './monitoring'
 const exposeDocs = true
 
 const port = Number(process.env.PORT) || 5000;
-const host = process.env.HOST || '0.0.0.0'
+const host = process.env.HOST as string || '0.0.0.0'
 
 ;(async () => {
   const { isMultitenant, requestIdHeader, adminRequestIdHeader } = getConfig()


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Server binds to hard coded address 0.0.0.0:5000

Closes #217

## What is the new behavior?

Uses the variables HOST and PORT for the address to bind to when provided. If not set, defaults to 0.0.0.0:5000

See below, logs from the modified storage-api on fly.io
![image](https://user-images.githubusercontent.com/48126337/201749713-34f05be7-a2f6-41ec-aa65-5075f90af78e.png)

