### PR TITLE
fix: commit analyzer preset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,9 @@
     "master"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+        "preset": "conventionalcommits"
+    }],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Sometimes CI doesn't pickup conventional commits properly

## What is the new behavior?

The default preset is `angular` now is changed to `conventionalcommits`

