### PR TITLE
fix: Handle 404 gracefully for public objects

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -26,7 +26,7 @@ export const setErrorHandler = (app: FastifyInstance) => {
     // Fastify errors
     if ('statusCode' in error) {
       const err = error as FastifyError
-      return reply.status((error as any).statusCode).send({
+      return reply.status((error as any).statusCode || 500).send({
         statusCode: `${err.statusCode}`,
         error: err.name,
         message: err.message,

--- a/src/http/routes/object/getPublicObject.ts
+++ b/src/http/routes/object/getPublicObject.ts
@@ -47,9 +47,12 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
       const { download } = request.query
 
-      await request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
-        isPublic: true,
-      })
+      await Promise.all([
+        request.storage.asSuperUser().findBucket(bucketName, 'id,public', {
+          isPublic: true,
+        }),
+        request.storage.asSuperUser().from(bucketName).findObject(objectName),
+      ])
 
       // send the object from s3
       const s3Key = `${request.tenantId}/${bucketName}/${objectName}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, we bubble up S3 error to the client when accessing a non-existing public object 

## What is the new behavior?

We will return 404
