### PR TITLE
fix: renaming render routes + enchantments

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,6 +23,7 @@ LOGFLARE_ENABLED=false
 LOGFLARE_API_KEY=api_key
 LOGFLARE_SOURCE_TOKEN=source_token
 
+ENABLE_IMAGE_TRANSFORMATION=false
 IMGPROXY_URL=http://localhost:50020
 
 # specify the extra headers will be persisted and passed into Postgrest client, for instance, "x-foo,x-bar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           MULTITENANT_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5433/postgres
           POSTGREST_URL_SUFFIX: /rest/v1
           ADMIN_API_KEYS: apikey
+          ENABLE_IMAGE_TRANSFORMATION: true
           IMGPROXY_URL: http://127.0.0.1:50020
 
       - name: Upload coverage results to Coveralls

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,7 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.register(plugins.logRequest({ excludeUrls: ['/status'] }))
   app.register(routes.bucket, { prefix: 'bucket' })
   app.register(routes.object, { prefix: 'object' })
-  app.register(routes.render, { prefix: 'render' })
+  app.register(routes.render, { prefix: 'render/image' })
 
   setErrorHandler(app)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ type StorageConfigType = {
   pgQueueConnectionURL?: string
   webhookURL?: string
   webhookApiKey?: string
-  disableImageTransformation: boolean
+  enableImageTransformation: boolean
   imgProxyURL?: string
   imgProxyRequestTimeout: number
   imgLimits: {
@@ -102,7 +102,7 @@ export function getConfig(): StorageConfigType {
     pgQueueConnectionURL: getOptionalConfigFromEnv('PG_QUEUE_CONNECTION_URL'),
     webhookURL: getOptionalConfigFromEnv('WEBHOOK_URL'),
     webhookApiKey: getOptionalConfigFromEnv('WEBHOOK_API_KEY'),
-    disableImageTransformation: getOptionalConfigFromEnv('DISABLE_IMAGE_TRANSFORMATION') === 'true',
+    enableImageTransformation: getOptionalConfigFromEnv('ENABLE_IMAGE_TRANSFORMATION') === 'true',
     imgProxyRequestTimeout: parseInt(
       getOptionalConfigFromEnv('IMGPROXY_REQUEST_TIMEOUT') || '15',
       10

--- a/src/http/routes/render/index.ts
+++ b/src/http/routes/render/index.ts
@@ -1,13 +1,14 @@
 import { FastifyInstance } from 'fastify'
 import renderPublicImage from './renderPublicImage'
 import renderAuthenticatedImage from './renderAuthenticatedImage'
+import renderSignedImage from './renderSignedImage'
 import { jwt, postgrest, superUserPostgrest, storage } from '../../plugins'
 import { getConfig } from '../../../config'
 
-const { disableImageTransformation } = getConfig()
+const { enableImageTransformation } = getConfig()
 
 export default async function routes(fastify: FastifyInstance) {
-  if (disableImageTransformation) {
+  if (!enableImageTransformation) {
     return
   }
 
@@ -22,6 +23,7 @@ export default async function routes(fastify: FastifyInstance) {
   fastify.register(async (fastify) => {
     fastify.register(superUserPostgrest)
     fastify.register(storage)
+    fastify.register(renderSignedImage)
     fastify.register(renderPublicImage)
   })
 }

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -20,6 +20,7 @@ const renderImageQuerySchema = {
     height: { type: 'integer', examples: [100], minimum: 0 },
     width: { type: 'integer', examples: [100], minimum: 0 },
     resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+    download: { type: 'string' },
   },
 } as const
 
@@ -42,6 +43,7 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
+      const { download } = request.query
       const { bucketName } = request.params
       const objectName = request.params['*']
 
@@ -54,6 +56,7 @@ export default async function routes(fastify: FastifyInstance) {
       return renderer.setTransformations(request.query).render(request, response, {
         bucket: globalS3Bucket,
         key: s3Key,
+        download,
       })
     }
   )

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -2,14 +2,15 @@ import { getConfig } from '../../../config'
 import { FromSchema } from 'json-schema-to-ts'
 import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '../../../storage/renderer'
+import { getJwtSecret, SignedToken, verifyJWT } from '../../../auth'
+import { StorageBackendError } from '../../../storage'
 
 const { globalS3Bucket } = getConfig()
 
-const renderPublicImageParamsSchema = {
+const renderAuthenticatedImageParamsSchema = {
   type: 'object',
   properties: {
     bucketName: { type: 'string', examples: ['avatars'] },
-    download: { type: 'string' },
     '*': { type: 'string', examples: ['folder/cat.png'] },
   },
   required: ['bucketName', '*'],
@@ -21,22 +22,24 @@ const renderImageQuerySchema = {
     height: { type: 'integer', examples: [100], minimum: 0 },
     width: { type: 'integer', examples: [100], minimum: 0 },
     resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+    token: { type: 'string' },
     download: { type: 'string' },
   },
+  required: ['token'],
 } as const
 
 interface renderImageRequestInterface {
-  Params: FromSchema<typeof renderPublicImageParamsSchema>
+  Params: FromSchema<typeof renderAuthenticatedImageParamsSchema>
   Querystring: FromSchema<typeof renderImageQuerySchema>
 }
 
 export default async function routes(fastify: FastifyInstance) {
-  const summary = 'Render a public image with the given transformations'
+  const summary = 'Render an authenticated image with the given transformations'
   fastify.get<renderImageRequestInterface>(
-    '/public/:bucketName/*',
+    '/signed/:bucketName/*',
     {
       schema: {
-        params: renderPublicImageParamsSchema,
+        params: renderAuthenticatedImageParamsSchema,
         querystring: renderImageQuerySchema,
         summary,
         response: { '4xx': { $ref: 'errorSchema#', description: 'Error response' } },
@@ -44,13 +47,22 @@ export default async function routes(fastify: FastifyInstance) {
       },
     },
     async (request, response) => {
+      const { token } = request.query
       const { download } = request.query
-      const { bucketName } = request.params
-      const objectName = request.params['*']
 
-      await request.storage.asSuperUser().from(bucketName).findObject(objectName)
+      let payload: SignedToken
+      const jwtSecret = await getJwtSecret(request.tenantId)
 
-      const s3Key = `${request.tenantId}/${bucketName}/${objectName}`
+      try {
+        payload = (await verifyJWT(token, jwtSecret)) as SignedToken
+      } catch (e) {
+        const err = e as Error
+        throw new StorageBackendError('Invalid JWT', 400, err.message, err)
+      }
+
+      const { url } = payload
+      const s3Key = `${request.tenantId}/${url}`
+      request.log.info(s3Key)
 
       const renderer = request.storage.renderer('image') as ImageRenderer
 

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -98,8 +98,6 @@ export class ImageRenderer extends Renderer {
       privateURL.startsWith('local://') ? privateURL : encodeURIComponent(privateURL),
     ]
 
-    console.log(url.join('/'))
-
     try {
       const response = await this.getClient().get(url.join('/'), {
         responseType: 'stream',

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -34,7 +34,7 @@ describe('image rendering routes', () => {
 
     const response = await app().inject({
       method: 'GET',
-      url: '/render/authenticated/bucket2/authenticated/casestudy.png?width=100&height=100',
+      url: '/render/image/authenticated/bucket2/authenticated/casestudy.png?width=100&height=100',
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
@@ -55,7 +55,7 @@ describe('image rendering routes', () => {
 
     const response = await app().inject({
       method: 'GET',
-      url: '/render/public/public-bucket-2/favicon.ico?width=100&height=100',
+      url: '/render/image/public/public-bucket-2/favicon.ico?width=100&height=100',
     })
 
     expect(response.statusCode).toBe(200)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes

## What is the current behavior?

- render route is too generic
- is not possible to transform images using a signed URL
- downloading transformed image is not supported

## What is the new behaviour?

- renamed render route to be more explicit `/render/image` 
- support signed URL transformations
- support download for transformed images
- Improved error handling
- renamed ENV variable `DISABLE_IMAGE_TRANSFORMATION` to `ENABLE_IMAGE_TRANSFORMATION`
