### PR TITLE
fix: prevent move operation to the same destination

### DIFF
--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -26,6 +26,7 @@ export abstract class Queue {
     }
     Queue.pgBoss = new PgBoss({
       connectionString: url,
+      max: 4,
       application_name: 'storage-api',
       deleteAfterDays: 7,
       retentionDays: 7,

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -313,6 +313,10 @@ export class ObjectStorage {
   async moveObject(sourceObjectName: string, destinationObjectName: string) {
     mustBeValidKey(destinationObjectName, 'The destination object name contains invalid characters')
 
+    if (sourceObjectName === destinationObjectName) {
+      return
+    }
+
     await this.db.updateObjectName(this.bucketId, sourceObjectName, destinationObjectName)
 
     const s3SourceKey = `${this.db.tenantId}/${this.bucketId}/${sourceObjectName}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If we try to move an object to a destination that is the same as the source we end up deleting the file

## What is the new behavior?

Prevent move operations to the same destination as the source 