### PR TITLE
fix: embed transformation params in the signed url token

### DIFF
--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -10,6 +10,7 @@ interface jwtInterface {
 
 export type SignedToken = {
   url: string
+  transformations?: string
 }
 
 /**

--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -14,8 +14,6 @@ export const setErrorHandler = (app: FastifyInstance) => {
     // it will be logged in the request log plugin
     reply.executionError = error
 
-    request.log.error({ error }, `request error | ${request.id}`)
-
     if (process.env.NODE_ENV !== 'production') {
       console.error(error)
     }

--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -2,6 +2,7 @@ import { getConfig } from '../../../config'
 import { FromSchema } from 'json-schema-to-ts'
 import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '../../../storage/renderer'
+import { transformationQueryString } from '../../schemas/transformations'
 
 const { globalS3Bucket } = getConfig()
 
@@ -17,9 +18,7 @@ const renderAuthenticatedImageParamsSchema = {
 const renderImageQuerySchema = {
   type: 'object',
   properties: {
-    height: { type: 'integer', examples: [100], minimum: 0 },
-    width: { type: 'integer', examples: [100], minimum: 0 },
-    resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+    ...transformationQueryString,
     download: { type: 'string' },
   },
 } as const

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -2,6 +2,7 @@ import { getConfig } from '../../../config'
 import { FromSchema } from 'json-schema-to-ts'
 import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '../../../storage/renderer'
+import { transformationQueryString } from '../../schemas/transformations'
 
 const { globalS3Bucket } = getConfig()
 
@@ -18,9 +19,7 @@ const renderPublicImageParamsSchema = {
 const renderImageQuerySchema = {
   type: 'object',
   properties: {
-    height: { type: 'integer', examples: [100], minimum: 0 },
-    width: { type: 'integer', examples: [100], minimum: 0 },
-    resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+    ...transformationQueryString,
     download: { type: 'string' },
   },
 } as const

--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -1,0 +1,5 @@
+export const transformationQueryString = {
+  height: { type: 'integer', examples: [100], minimum: 0 },
+  width: { type: 'integer', examples: [100], minimum: 0 },
+  resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+} as const

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -1,4 +1,4 @@
-import { StorageBackendAdapter, ObjectMetadata } from '../backend'
+import { ObjectMetadata, StorageBackendAdapter } from '../backend'
 import axios, { Axios, AxiosError } from 'axios'
 import { getConfig } from '../../config'
 import { FastifyRequest } from 'fastify'
@@ -80,6 +80,27 @@ export class ImageRenderer extends Renderer {
     return this
   }
 
+  setTransformationsFromString(transformations: string) {
+    const params = transformations.split(',')
+
+    this.transformOptions = params.reduce((all, param) => {
+      const [name, value] = param.split(':') as [keyof TransformOptions, any]
+      switch (name) {
+        case 'height':
+          all.height = parseInt(value, 10)
+          break
+        case 'width':
+          all.width = parseInt(value, 10)
+          break
+        case 'resize':
+          all.resize = value
+      }
+      return all
+    }, {} as TransformOptions)
+
+    return this
+  }
+
   /**
    * Fetch the transformed asset from imgproxy.
    * We use a secure signed url in order for imgproxy to download and
@@ -134,7 +155,7 @@ export class ImageRenderer extends Renderer {
    * Applies whitelisted transformations with specific limits applied
    * @param options
    */
-  static applyTransformation(options: TransformOptions) {
+  static applyTransformation(options: TransformOptions): string[] {
     const segments = []
 
     if (options.height) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

transforming signed URL assets is currently done when requesting the resource

## What is the new behavior?

the transformation parameters are now part of the JWT token and can't be changed once the token is signed
