### PR TITLE
fix: use body instead of query params

### DIFF
--- a/src/http/routes/render/renderAuthenticatedImage.ts
+++ b/src/http/routes/render/renderAuthenticatedImage.ts
@@ -2,7 +2,7 @@ import { getConfig } from '../../../config'
 import { FromSchema } from 'json-schema-to-ts'
 import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '../../../storage/renderer'
-import { transformationQueryString } from '../../schemas/transformations'
+import { transformationOptionsSchema } from '../../schemas/transformations'
 
 const { globalS3Bucket } = getConfig()
 
@@ -18,7 +18,7 @@ const renderAuthenticatedImageParamsSchema = {
 const renderImageQuerySchema = {
   type: 'object',
   properties: {
-    ...transformationQueryString,
+    ...transformationOptionsSchema,
     download: { type: 'string' },
   },
 } as const

--- a/src/http/routes/render/renderPublicImage.ts
+++ b/src/http/routes/render/renderPublicImage.ts
@@ -2,7 +2,7 @@ import { getConfig } from '../../../config'
 import { FromSchema } from 'json-schema-to-ts'
 import { FastifyInstance } from 'fastify'
 import { ImageRenderer } from '../../../storage/renderer'
-import { transformationQueryString } from '../../schemas/transformations'
+import { transformationOptionsSchema } from '../../schemas/transformations'
 
 const { globalS3Bucket } = getConfig()
 
@@ -19,7 +19,7 @@ const renderPublicImageParamsSchema = {
 const renderImageQuerySchema = {
   type: 'object',
   properties: {
-    ...transformationQueryString,
+    ...transformationOptionsSchema,
     download: { type: 'string' },
   },
 } as const

--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -1,4 +1,4 @@
-export const transformationQueryString = {
+export const transformationOptionsSchema = {
   height: { type: 'integer', examples: [100], minimum: 0 },
   width: { type: 'integer', examples: [100], minimum: 0 },
   resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },

--- a/src/test/render-routes.test.ts
+++ b/src/test/render-routes.test.ts
@@ -69,9 +69,13 @@ describe('image rendering routes', () => {
   it('will render a transformed image providing a signed url', async () => {
     const signURLResponse = await app().inject({
       method: 'POST',
-      url: '/object/sign/bucket2/authenticated/casestudy.png?width=100&height=100',
+      url: '/object/sign/bucket2/authenticated/casestudy.png',
       payload: {
         expiresIn: 60000,
+        transform: {
+          width: 100,
+          height: 100,
+        },
       },
       headers: {
         authorization: `Bearer ${process.env.SERVICE_KEY}`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Query string params are used in a POST request to determine transformations

## What is the new behavior?

Use body to pass transformations params
