### PR TITLE
fix: map resizing options

### DIFF
--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -1,5 +1,5 @@
 export const transformationOptionsSchema = {
   height: { type: 'integer', examples: [100], minimum: 0 },
   width: { type: 'integer', examples: [100], minimum: 0 },
-  resize: { type: 'string', enum: ['fill', 'fit', 'fill-down', 'force', 'auto'] },
+  resize: { type: 'string', enum: ['cover', 'contain', 'fill'] },
 } as const

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -13,7 +13,7 @@ import { Stream } from 'stream'
 export interface TransformOptions {
   width?: number
   height?: number
-  resize?: 'fill' | 'fit' | 'fill-down' | 'force' | 'auto'
+  resize?: 'cover' | 'contain' | 'fill'
 }
 
 const { imgLimits, imgProxyURL, imgProxyRequestTimeout } = getConfig()
@@ -167,10 +167,25 @@ export class ImageRenderer extends Renderer {
     }
 
     if (options.width || options.height) {
-      segments.push(`resizing_type:${options.resize || 'fill'}`)
+      segments.push(`resizing_type:${this.formatResizeType(options.resize)}`)
     }
 
     return segments
+  }
+
+  protected static formatResizeType(resize: TransformOptions['resize']) {
+    const defaultResize = 'fill'
+
+    switch (resize) {
+      case 'cover':
+        return defaultResize
+      case 'contain':
+        return 'fit'
+      case 'fill':
+        return 'force'
+      default:
+        return defaultResize
+    }
   }
 
   protected async handleRequestError(error: AxiosError) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the new behavior?

mapping imgproxy resize_type with custom values

- Rename `fit` to `contain`
- Rename `fill` to `cover`
- Rename `force` to `fill`