### PR TITLE
fix: consistent etags + use expires header on signed urls

### DIFF
--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -11,6 +11,7 @@ interface jwtInterface {
 export type SignedToken = {
   url: string
   transformations?: string
+  exp: number
 }
 
 /**

--- a/src/http/routes/object/getSignedObject.ts
+++ b/src/http/routes/object/getSignedObject.ts
@@ -65,7 +65,7 @@ export default async function routes(fastify: FastifyInstance) {
         throw new StorageBackendError('Invalid JWT', 400, err.message, err)
       }
 
-      const { url } = payload
+      const { url, exp } = payload
       const s3Key = `${request.tenantId}/${url}`
       request.log.info(s3Key)
 
@@ -73,6 +73,7 @@ export default async function routes(fastify: FastifyInstance) {
         bucket: globalS3Bucket,
         key: s3Key,
         download,
+        expires: new Date(exp * 1000).toUTCString(),
       })
     }
   )

--- a/src/http/routes/render/renderSignedImage.ts
+++ b/src/http/routes/render/renderSignedImage.ts
@@ -57,7 +57,7 @@ export default async function routes(fastify: FastifyInstance) {
         throw new StorageBackendError('Invalid JWT', 400, err.message, err)
       }
 
-      const { url, transformations } = payload
+      const { url, transformations, exp } = payload
       const s3Key = `${request.tenantId}/${url}`
       request.log.info(s3Key)
 
@@ -68,6 +68,7 @@ export default async function routes(fastify: FastifyInstance) {
           bucket: globalS3Bucket,
           key: s3Key,
           download,
+          expires: new Date(exp * 1000).toUTCString(),
         })
     }
   )

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -109,7 +109,10 @@ export class ImageRenderer extends Renderer {
    * @param options
    */
   async getAsset(request: FastifyRequest, options: RenderOptions) {
-    const privateURL = await this.backend.privateAssetUrl(options.bucket, options.key)
+    const [privateURL, headObj] = await Promise.all([
+      this.backend.privateAssetUrl(options.bucket, options.key),
+      this.backend.headObject(options.bucket, options.key),
+    ])
     const transformations = ImageRenderer.applyTransformation(this.transformOptions || {})
 
     const url = [
@@ -132,6 +135,7 @@ export class ImageRenderer extends Renderer {
       return {
         body: response.data,
         transformations,
+        originalEtag: headObj.eTag,
         metadata: {
           httpStatusCode: response.status,
           size: contentLength,

--- a/src/test/webhooks.test.ts
+++ b/src/test/webhooks.test.ts
@@ -245,7 +245,7 @@ describe('Webhooks', () => {
                 cacheControl: 'no-cache',
                 contentLength: 3746,
                 eTag: 'abc',
-                lastModified: expect.any(String),
+                lastModified: expect.any(Date),
                 httpStatusCode: 200,
                 mimetype: 'image/png',
                 size: 3746,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- etags were out of sync with S3 during copy and move operations
- signed URL is using `cache-control` header instead of `expires` which means that the CDN cache doesn't honor the JWT expiry date

## What is the new behavior?

- etags are now in sync with s3 during copy and move operations
- signed URL now returns the `expires` header with the date set as the JWT expiry date
