### PR TITLE
chore: whitelist x-client-trace-id header to be logged

### DIFF
--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -67,6 +67,7 @@ const whitelistHeaders = (headers: Record<string, unknown>) => {
     'x-real-ip',
     'x-client-info',
     'x-forwarded-user-agent',
+    'x-client-trace-id',
   ]
   const allowlistedResponseHeaders = [
     'cf-cache-status',


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Whitelist x-client-trace-id to be logged
