### PR TITLE
chore: removes trailing space from migration file

### DIFF
--- a/migrations/tenant/0002-pathtoken-column.sql
+++ b/migrations/tenant/0002-pathtoken-column.sql
@@ -1,7 +1,7 @@
 alter table storage.objects add column path_tokens text[] generated always as (string_to_array("name", '/')) stored;
 
 CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits int DEFAULT 100, levels int DEFAULT 1, offsets int DEFAULT 0)
- RETURNS TABLE (
+  RETURNS TABLE (
     name text,
     id uuid,
     updated_at TIMESTAMPTZ,
@@ -9,22 +9,22 @@ CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits i
     last_accessed_at TIMESTAMPTZ,
     metadata jsonb
   )
- LANGUAGE plpgsql
+  LANGUAGE plpgsql
 AS $function$
 BEGIN
-	return query 
-		with files_folders as (
-			select path_tokens[levels] as folder
-			from storage.objects
-			where objects.name ilike prefix || '%'
-			and bucket_id = bucketname
-			GROUP by folder
-			limit limits
-			offset offsets
-		) 
-		select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders 
-		left join storage.objects
-		on prefix || files_folders.folder = objects.name
-        where objects.id is null or objects.bucket_id=bucketname;
+  return query
+    with files_folders as (
+      select path_tokens[levels] as folder
+      from storage.objects
+      where objects.name ilike prefix || '%'
+      and bucket_id = bucketname
+      GROUP by folder
+      limit limits
+      offset offsets
+    )
+    select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders
+    left join storage.objects
+    on prefix || files_folders.folder = objects.name
+    where objects.id is null or objects.bucket_id=bucketname;
 END
 $function$;

--- a/migrations/tenant/0004-add-size-functions.sql
+++ b/migrations/tenant/0004-add-size-functions.sql
@@ -1,14 +1,14 @@
 CREATE OR REPLACE FUNCTION storage.get_size_by_bucket()
- RETURNS TABLE (
+  RETURNS TABLE (
     size BIGINT,
     bucket text
   )
- LANGUAGE plpgsql
+  LANGUAGE plpgsql
 AS $function$
 BEGIN
-    return query
-        select sum((metadata->>'size')::int) as size, bucket_id as bucket
-        from "storage".objects
-        group by bucket_id;
+  return query
+    select sum((metadata->>'size')::int) as size, bucket_id as bucket
+    from "storage".objects
+    group by bucket_id;
 END
 $function$;

--- a/migrations/tenant/0005-change-column-name-in-get-size.sql
+++ b/migrations/tenant/0005-change-column-name-in-get-size.sql
@@ -1,15 +1,15 @@
 DROP FUNCTION storage.get_size_by_bucket();
 CREATE OR REPLACE FUNCTION storage.get_size_by_bucket()
- RETURNS TABLE (
+  RETURNS TABLE (
     size BIGINT,
     bucket_id text
   )
- LANGUAGE plpgsql
+  LANGUAGE plpgsql
 AS $function$
 BEGIN
-    return query
-        select sum((metadata->>'size')::int) as size, obj.bucket_id
-        from "storage".objects as obj
-        group by obj.bucket_id;
+  return query
+    select sum((metadata->>'size')::int) as size, obj.bucket_id
+    from "storage".objects as obj
+    group by obj.bucket_id;
 END
 $function$;

--- a/migrations/tenant/0008-fix-search-function.sql
+++ b/migrations/tenant/0008-fix-search-function.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits int DEFAULT 100, levels int DEFAULT 1, offsets int DEFAULT 0)
- RETURNS TABLE (
+  RETURNS TABLE (
     name text,
     id uuid,
     updated_at TIMESTAMPTZ,
@@ -7,21 +7,21 @@ CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits i
     last_accessed_at TIMESTAMPTZ,
     metadata jsonb
   )
- LANGUAGE plpgsql
+  LANGUAGE plpgsql
 AS $function$
 BEGIN
-	return query 
-		with files_folders as (
-			select path_tokens[levels] as folder
-			from storage.objects
-			where objects.name ilike prefix || '%'
-			and bucket_id = bucketname
-			GROUP by folder
-			limit limits
-			offset offsets
-		) 
-		select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders 
-		left join storage.objects
-		on prefix || files_folders.folder = objects.name and objects.bucket_id=bucketname;
+  return query
+    with files_folders as (
+      select path_tokens[levels] as folder
+      from storage.objects
+      where objects.name ilike prefix || '%'
+      and bucket_id = bucketname
+      GROUP by folder
+      limit limits
+      offset offsets
+    )
+    select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders
+    left join storage.objects
+    on prefix || files_folders.folder = objects.name and objects.bucket_id=bucketname;
 END
 $function$;

--- a/migrations/tenant/0010-add-trigger-to-auto-update-updated_at-column.sql
+++ b/migrations/tenant/0010-add-trigger-to-auto-update-updated_at-column.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = now();
-    RETURN NEW; 
+    RETURN NEW;
 END;
 $$ language plpgsql;
 

--- a/migrations/tenant/0010-add-trigger-to-auto-update-updated_at-column.sql
+++ b/migrations/tenant/0010-add-trigger-to-auto-update-updated_at-column.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE FUNCTION update_updated_at_column() 
+CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.updated_at = now();
-    RETURN NEW;
+  NEW.updated_at = now();
+  RETURN NEW;
 END;
 $$ language plpgsql;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

style

## What is the current behavior?

identified by a CLI user https://github.com/supabase/cli/pull/648

## What is the new behavior?

removes trailing space

## Additional context

Add any other context or screenshots.
