### PR TITLE
feat(object): Allow for presigning upload url

### DIFF
--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -1,0 +1,68 @@
+import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
+import { createDefaultSchema } from '../../generic-routes'
+import { AuthenticatedRequest } from '../../request'
+
+const getSignedUploadURLParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+const getSignedUploadURLBodySchema = {
+  type: 'object',
+  properties: {
+    expiresIn: { type: 'integer', minimum: 1, examples: [60000] },
+  },
+  required: ['expiresIn'],
+} as const
+
+const successResponseSchema = {
+  type: 'object',
+  properties: {
+    signedUploadURL: {
+      type: 'string',
+      examples: [
+        '/object/sign/upload/avatars/folder/cat.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJhdmF0YXJzL2ZvbGRlci9jYXQucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.s7Gt8ME80iREVxPhH01ZNv8oUn4XtaWsmiQ5csiUHn4',
+      ],
+    },
+  },
+  required: ['signedUploadURL'],
+}
+interface getSignedURLRequestInterface extends AuthenticatedRequest {
+  Params: FromSchema<typeof getSignedUploadURLParamsSchema>
+  Body: FromSchema<typeof getSignedUploadURLBodySchema>
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Generate a presigned url to upload an object'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: getSignedUploadURLBodySchema,
+    params: getSignedUploadURLParamsSchema,
+    summary,
+    tags: ['object'],
+  })
+
+  fastify.post<getSignedURLRequestInterface>(
+    '/upload/sign/:bucketName/*',
+    {
+      schema,
+    },
+    async (request, response) => {
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+      const { expiresIn } = request.body
+
+      const urlPath = request.url.split('?').shift()
+
+      const signedUploadURL = await request.storage
+        .from(bucketName)
+        .signUploadObjectUrl(objectName, urlPath as string, expiresIn)
+
+      return response.status(200).send({ signedUploadURL })
+    }
+  )
+}

--- a/src/http/routes/object/index.ts
+++ b/src/http/routes/object/index.ts
@@ -16,6 +16,8 @@ import {
   publicRoutes as getObjectInfoPublic,
   authenticatedRoutes as getObjectInfoAuth,
 } from './getObjectInfo'
+import getSignedUploadURL from './getSignedUploadURL'
+import uploadSignedObject from './uploadSignedObject'
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(async function authorizationContext(fastify) {
@@ -27,6 +29,7 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(deleteObject)
     fastify.register(deleteObjects)
     fastify.register(getObject)
+    fastify.register(getSignedUploadURL)
     fastify.register(getSignedURL)
     fastify.register(getSignedURLs)
     fastify.register(moveObject)
@@ -42,6 +45,7 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(storage)
     fastify.register(getPublicObject)
     fastify.register(getSignedObject)
+    fastify.register(uploadSignedObject)
     fastify.register(getObjectInfoPublic)
   })
 }

--- a/src/http/routes/object/uploadSignedObject.ts
+++ b/src/http/routes/object/uploadSignedObject.ts
@@ -1,0 +1,101 @@
+import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
+import { getJwtSecret, getOwner, verifyJWT } from '../../../auth'
+import { StorageBackendError } from '../../../storage'
+
+const uploadSignedObjectParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+
+const uploadSignedObjectQSSchema = {
+  type: 'object',
+  properties: {
+    token: {
+      type: 'string',
+      examples: [
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJidWNrZXQyL3B1YmxpYy9zYWRjYXQtdXBsb2FkMjMucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.uBQcXzuvXxfw-9WgzWMBfE_nR3VOgpvfZe032sfLSSk',
+      ],
+    },
+  },
+  required: ['token'],
+} as const
+
+const successResponseSchema = {
+  type: 'object',
+  properties: {
+    Key: { type: 'string', examples: ['projectref/avatars/folder/cat.png'] },
+  },
+  required: ['Key'],
+}
+
+interface UploadSignedObjectRequestInterface {
+  Params: FromSchema<typeof uploadSignedObjectParamsSchema>
+  Querystring: FromSchema<typeof uploadSignedObjectQSSchema>
+  Headers: {
+    range?: string
+  }
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Uploads an object via a presigned URL'
+
+  fastify.addContentTypeParser(
+    ['application/json', 'text/plain'],
+    function (request, payload, done) {
+      done(null)
+    }
+  )
+
+  fastify.put<UploadSignedObjectRequestInterface>(
+    '/upload/sign/:bucketName/*',
+    {
+      // @todo add success response schema here
+      schema: {
+        params: uploadSignedObjectParamsSchema,
+        querystring: uploadSignedObjectQSSchema,
+        summary,
+        response: {
+          200: { description: 'Succesful response', ...successResponseSchema },
+          '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+        },
+        tags: ['object'],
+      },
+    },
+    async (request, response) => {
+      // Validate sender
+      const { token } = request.query
+
+      const jwtSecret = await getJwtSecret(request.tenantId)
+      try {
+        await verifyJWT(token, jwtSecret)
+      } catch (e) {
+        const err = e as Error
+        throw new StorageBackendError('Invalid JWT', 400, err.message, err)
+      }
+
+      const contentType = request.headers['content-type']
+      request.log.info(`content-type is ${contentType}`)
+
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+      const owner = await getOwner(token, jwtSecret)
+
+      const { objectMetadata, path } = await request.storage
+        .asSuperUser()
+        .from(bucketName)
+        .uploadNewObject(request, {
+          owner,
+          objectName: objectName,
+        })
+
+      return response.status(objectMetadata?.httpStatusCode ?? 200).send({
+        Key: path,
+      })
+    }
+  )
+}

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1145,6 +1145,82 @@ describe('testing generating signed URL', () => {
 })
 
 /**
+ * POST /upload/sign/:bucketName/*
+ */
+
+describe('testing generating signed URL for upload', () => {
+  test('check if RLS policies are respected: authenticated user is able to sign upload URL for a resource', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    const result = JSON.parse(response.body)
+    expect(result.signedUploadURL).toBeTruthy()
+  })
+
+  test('user is not able to sign a upload url without Auth header', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('return 400 when generating signed upload urls from a non existent bucket', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/notfound/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('signing upload url of a non existent key', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/notfound.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('signing upload url of an existent key', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(JSON.parse(response.body).statusCode).toBe('409')
+  })
+})
+
+/**
  * POST /sign/:bucketName
  */
 describe('testing generating signed URLs', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces a new **feature** to sign an upload url, which allows for uploading straight to the bucket without credentials.

## What is the current behavior?

It's currently not possible to upload a file from the client side, without routing it through your own server, which is not the preferred way.

## What is the new behavior?

You can now presign a upload url with your service token, and give the url to any client which can then upload the file directly.

## Additional context
Closes #81 

Add any other context or screenshots.
_First PR for the Storage API_