### PR TITLE
fix: use custom etag instead of the response etag + add graceful-shut…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,4 +60,14 @@ const exposeDocs = true
     }
     console.log(`Server listening at ${address}`)
   })
+
+  process.on('SIGTERM', async () => {
+    try {
+      await app.close()
+      process.exit(0)
+    } catch (e) {
+      logger.error('shutdown error', { error: e })
+      process.exit(1)
+    }
+  })
 })()

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -135,14 +135,13 @@ export class ImageRenderer extends Renderer {
       return {
         body: response.data,
         transformations,
-        originalEtag: headObj.eTag,
         metadata: {
           httpStatusCode: response.status,
           size: contentLength,
           contentLength: contentLength,
           lastModified: lastModified,
-          eTag: response.headers['etag'],
-          cacheControl: response.headers['cache-control'],
+          eTag: headObj.eTag,
+          cacheControl: headObj.cacheControl,
           mimetype: response.headers['content-type'],
         } as ObjectMetadata,
       }

--- a/src/storage/renderer/renderer.ts
+++ b/src/storage/renderer/renderer.ts
@@ -13,7 +13,6 @@ export interface AssetResponse {
   body?: Readable | ReadableStream<any> | Blob | Buffer
   metadata: ObjectMetadata
   transformations?: string[]
-  originalEtag?: string
 }
 
 /**
@@ -76,10 +75,6 @@ export abstract class Renderer {
 
     if (data.transformations && data.transformations.length > 0) {
       response.header('X-Transformations', data.transformations.join(','))
-    }
-
-    if (data.originalEtag) {
-      response.header('x-origin-etag', data.originalEtag)
     }
 
     this.handleDownload(response, options.download)


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix,

## What is the new behavior?

- Fastify graceful shutdown
- use storage-api instead of relying on response etags
