### PR TITLE
fix: unsupported extended file attributes on macOS

### DIFF
--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -14,6 +14,18 @@ interface FileMetadata {
   contentType: string
 }
 
+// file metadata attribute keys on different platforms
+const METADATA_ATTR_KEYS = {
+  'darwin': {
+    'cache-control': 'com.apple.metadata.supabase.cache-control',
+    'content-type': 'com.apple.metadata.supabase.content-type',
+  },
+  'linux': {
+    'cache-control': 'user.supabase.cache-control',
+    'content-type': 'user.supabase.content-type',
+  },
+};
+
 /**
  * FileBackend
  * Interacts with the file system with this FileBackend adapter
@@ -177,9 +189,10 @@ export class FileBackend implements StorageBackendAdapter {
   }
 
   protected async getFileMetadata(file: string) {
+    const platform = process.platform == 'darwin' ? 'darwin' : 'linux';
     const [cacheControl, contentType] = await Promise.all([
-      this.getMetadataAttr(file, 'user.supabase.cache-control'),
-      this.getMetadataAttr(file, 'user.supabase.content-type'),
+      this.getMetadataAttr(file, METADATA_ATTR_KEYS[platform]['cache-control']),
+      this.getMetadataAttr(file, METADATA_ATTR_KEYS[platform]['content-type']),
     ])
 
     return {
@@ -189,9 +202,10 @@ export class FileBackend implements StorageBackendAdapter {
   }
 
   protected async setFileMetadata(file: string, { contentType, cacheControl }: FileMetadata) {
+    const platform = process.platform == 'darwin' ? 'darwin' : 'linux';
     await Promise.all([
-      this.setMetadataAttr(file, 'user.supabase.content-type', contentType),
-      this.setMetadataAttr(file, 'user.supabase.cache-control', cacheControl),
+      this.setMetadataAttr(file, METADATA_ATTR_KEYS[platform]['cache-control'], cacheControl),
+      this.setMetadataAttr(file, METADATA_ATTR_KEYS[platform]['content-type'], contentType),
     ])
   }
 

--- a/src/storage/backend/file.ts
+++ b/src/storage/backend/file.ts
@@ -16,15 +16,15 @@ interface FileMetadata {
 
 // file metadata attribute keys on different platforms
 const METADATA_ATTR_KEYS = {
-  'darwin': {
+  darwin: {
     'cache-control': 'com.apple.metadata.supabase.cache-control',
     'content-type': 'com.apple.metadata.supabase.content-type',
   },
-  'linux': {
+  linux: {
     'cache-control': 'user.supabase.cache-control',
     'content-type': 'user.supabase.content-type',
   },
-};
+}
 
 /**
  * FileBackend
@@ -189,7 +189,7 @@ export class FileBackend implements StorageBackendAdapter {
   }
 
   protected async getFileMetadata(file: string) {
-    const platform = process.platform == 'darwin' ? 'darwin' : 'linux';
+    const platform = process.platform == 'darwin' ? 'darwin' : 'linux'
     const [cacheControl, contentType] = await Promise.all([
       this.getMetadataAttr(file, METADATA_ATTR_KEYS[platform]['cache-control']),
       this.getMetadataAttr(file, METADATA_ATTR_KEYS[platform]['content-type']),
@@ -202,7 +202,7 @@ export class FileBackend implements StorageBackendAdapter {
   }
 
   protected async setFileMetadata(file: string, { contentType, cacheControl }: FileMetadata) {
-    const platform = process.platform == 'darwin' ? 'darwin' : 'linux';
+    const platform = process.platform == 'darwin' ? 'darwin' : 'linux'
     await Promise.all([
       this.setMetadataAttr(file, METADATA_ATTR_KEYS[platform]['cache-control'], cacheControl),
       this.setMetadataAttr(file, METADATA_ATTR_KEYS[platform]['content-type'], contentType),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix `The file system does not support extended attributes or has the feature disabled` error on macOS.

See:

https://github.com/supabase/supabase/issues/10745
https://github.com/supabase/supabase/discussions/9539

## What is the current behavior?

When trying to upload a file/image using to a locally hosted supabase instance, get the error:

`The file system does not support extended attributes or has the feature disabled`

## What is the new behavior?

There should be no error.

## Additional context

After this fix, user also need to enable `VirtioFS` in Docker desktop to be able to set file attribute.

![image](https://user-images.githubusercontent.com/19306324/208350343-b472e3f6-e1a5-443c-af7f-9fc401b51044.png)

