### PR TITLE
automatic webp support by default

### DIFF
--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -2,5 +2,5 @@ export const transformationOptionsSchema = {
   height: { type: 'integer', examples: [100], minimum: 0 },
   width: { type: 'integer', examples: [100], minimum: 0 },
   resize: { type: 'string', enum: ['cover', 'contain', 'fill'] },
-  format: { type: 'string', enum: ['auto'] },
+  format: { type: 'string', enum: ['origin'] },
 } as const

--- a/src/http/schemas/transformations.ts
+++ b/src/http/schemas/transformations.ts
@@ -2,4 +2,5 @@ export const transformationOptionsSchema = {
   height: { type: 'integer', examples: [100], minimum: 0 },
   width: { type: 'integer', examples: [100], minimum: 0 },
   resize: { type: 'string', enum: ['cover', 'contain', 'fill'] },
+  format: { type: 'string', enum: ['auto'] },
 } as const

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -14,7 +14,7 @@ export interface TransformOptions {
   width?: number
   height?: number
   resize?: 'cover' | 'contain' | 'fill'
-  format?: 'auto'
+  format?: 'origin'
 }
 
 const { imgLimits, imgProxyURL, imgProxyRequestTimeout } = getConfig()
@@ -129,7 +129,7 @@ export class ImageRenderer extends Renderer {
 
     try {
       const acceptHeader =
-        this.transformOptions?.format === 'auto' ? request.headers['accept'] : undefined
+        this.transformOptions?.format !== 'origin' ? request.headers['accept'] : undefined
 
       const response = await this.getClient().get(url.join('/'), {
         responseType: 'stream',

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -14,6 +14,7 @@ export interface TransformOptions {
   width?: number
   height?: number
   resize?: 'cover' | 'contain' | 'fill'
+  format?: 'auto'
 }
 
 const { imgLimits, imgProxyURL, imgProxyRequestTimeout } = getConfig()
@@ -94,6 +95,10 @@ export class ImageRenderer extends Renderer {
           break
         case 'resize':
           all.resize = value
+          break
+        case 'format':
+          all.format = value
+          break
       }
       return all
     }, {} as TransformOptions)
@@ -123,8 +128,16 @@ export class ImageRenderer extends Renderer {
     ]
 
     try {
+      const acceptHeader =
+        this.transformOptions?.format === 'auto' ? request.headers['accept'] : undefined
+
       const response = await this.getClient().get(url.join('/'), {
         responseType: 'stream',
+        headers: acceptHeader
+          ? {
+              accept: acceptHeader,
+            }
+          : undefined,
       })
 
       const contentLength = parseInt(response.headers['content-length'], 10)

--- a/src/test/db/docker-compose.yml
+++ b/src/test/db/docker-compose.yml
@@ -49,3 +49,4 @@ services:
     environment:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/images
       - IMGPROXY_USE_ETAG=true
+      - IMGPROXY_ENABLE_WEBP_DETECTION=true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Webp support needed to be opt-in by using a query string param

## What is the new behavior?

Automatic webp detection without additional parameters, use `format: origin` to disable this behaviour
