### PR TITLE
feat: allow to customise max file size and mime types at bucket level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=0 /app/node_modules node_modules
 COPY --from=1 /app/dist dist
 EXPOSE 5000
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["pm2-runtime", "ecosystem.config.js"]
+CMD ["node", "dist/server.js"]

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   apps: [
     {
+      instances: 'max',
       env: {
         NODE_ENV: 'production',
       },

--- a/migrations/tenant/0013-use-bytes-for-max-size.sql
+++ b/migrations/tenant/0013-use-bytes-for-max-size.sql
@@ -1,0 +1,2 @@
+ALTER TABLE storage.buckets RENAME COLUMN max_file_size_kb TO file_size_limit;
+ALTER TABLE storage.buckets ALTER COLUMN file_size_limit TYPE bigint;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fastify/rate-limit": "^7.6.0",
         "@fastify/swagger": "^7.4.1",
         "@supabase/postgrest-js": "^0.36.0",
+        "agentkeepalive": "^4.2.1",
         "axios": "^0.27.2",
         "axios-retry": "^3.3.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
@@ -3286,6 +3287,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -4539,6 +4553,25 @@
         "node-fetch": "2.6.7"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4660,6 +4693,14 @@
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/detect-newline": {
@@ -5878,6 +5919,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -7572,44 +7621,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9209,6 +9220,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -9673,6 +9689,20 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -12506,6 +12536,16 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -13501,6 +13541,16 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -13590,6 +13640,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -14539,6 +14594,14 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
     },
     "ieee754": {
       "version": "1.2.1",
@@ -15841,35 +15904,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -17081,6 +17115,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -17408,6 +17447,20 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@fastify/rate-limit": "^7.6.0",
     "@fastify/swagger": "^7.4.1",
     "@supabase/postgrest-js": "^0.36.0",
+    "agentkeepalive": "^4.2.1",
     "axios": "^0.27.2",
     "axios-retry": "^3.3.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,10 +2,13 @@ import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 import fastifyMultipart from '@fastify/multipart'
 import fastifySwagger from '@fastify/swagger'
 import { routes, schemas, plugins, setErrorHandler } from './http'
+import { getConfig } from './config'
 
 interface buildOpts extends FastifyServerOptions {
   exposeDocs?: boolean
 }
+
+const { keepAliveTimeout, headersTimeout } = getConfig()
 
 const build = (opts: buildOpts = {}): FastifyInstance => {
   const app = fastify(opts)
@@ -20,6 +23,9 @@ const build = (opts: buildOpts = {}): FastifyInstance => {
   app.addContentTypeParser('*', function (request, payload, done) {
     done(null)
   })
+
+  app.server.keepAliveTimeout = keepAliveTimeout * 1000
+  app.server.headersTimeout = headersTimeout * 1000
 
   // kong should take care of cors
   // app.register(fastifyCors)

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,12 +2,16 @@ import dotenv from 'dotenv'
 
 type StorageBackendType = 'file' | 's3'
 type StorageConfigType = {
+  keepAliveTimeout: number
+  headersTimeout: number
   adminApiKeys: string
   adminRequestIdHeader?: string
   anonKey: string
   encryptionKey: string
   fileSizeLimit: number
   fileStoragePath?: string
+  globalS3Protocol?: 'http' | 'https' | string
+  globalS3MaxSockets?: number
   globalS3Bucket: string
   globalS3Endpoint?: string
   globalS3ForcePathStyle?: boolean
@@ -37,6 +41,8 @@ type StorageConfigType = {
   enableImageTransformation: boolean
   imgProxyURL?: string
   imgProxyRequestTimeout: number
+  imgProxyHttpMaxSockets: number
+  imgProxyHttpKeepAlive: number
   imgLimits: {
     size: {
       min: number
@@ -75,12 +81,16 @@ export function getConfig(): StorageConfigType {
   dotenv.config()
 
   return {
+    keepAliveTimeout: parseInt(getOptionalConfigFromEnv('SERVER_KEEP_ALIVE_TIMEOUT') || '61', 10),
+    headersTimeout: parseInt(getOptionalConfigFromEnv('SERVER_HEADERS_TIMEOUT') || '65', 10),
     adminApiKeys: getOptionalConfigFromEnv('ADMIN_API_KEYS') || '',
     adminRequestIdHeader: getOptionalConfigFromEnv('ADMIN_REQUEST_ID_HEADER'),
     anonKey: getOptionalIfMultitenantConfigFromEnv('ANON_KEY') || '',
     encryptionKey: getOptionalConfigFromEnv('ENCRYPTION_KEY') || '',
     fileSizeLimit: Number(getConfigFromEnv('FILE_SIZE_LIMIT')),
     fileStoragePath: getOptionalConfigFromEnv('FILE_STORAGE_BACKEND_PATH'),
+    globalS3MaxSockets: parseInt(getOptionalConfigFromEnv('GLOBAL_S3_MAX_SOCKETS') || '200', 10),
+    globalS3Protocol: getOptionalConfigFromEnv('GLOBAL_S3_PROTOCOL') || 'https',
     globalS3Bucket: getConfigFromEnv('GLOBAL_S3_BUCKET'),
     globalS3Endpoint: getOptionalConfigFromEnv('GLOBAL_S3_ENDPOINT'),
     globalS3ForcePathStyle: getOptionalConfigFromEnv('GLOBAL_S3_FORCE_PATH_STYLE') === 'true',
@@ -115,6 +125,14 @@ export function getConfig(): StorageConfigType {
     enableImageTransformation: getOptionalConfigFromEnv('ENABLE_IMAGE_TRANSFORMATION') === 'true',
     imgProxyRequestTimeout: parseInt(
       getOptionalConfigFromEnv('IMGPROXY_REQUEST_TIMEOUT') || '15',
+      10
+    ),
+    imgProxyHttpMaxSockets: parseInt(
+      getOptionalConfigFromEnv('IMGPROXY_HTTP_MAX_SOCKETS') || '5000',
+      10
+    ),
+    imgProxyHttpKeepAlive: parseInt(
+      getOptionalConfigFromEnv('IMGPROXY_HTTP_KEEP_ALIVE_TIMEOUT') || '61',
       10
     ),
     imgProxyURL: getOptionalConfigFromEnv('IMGPROXY_URL'),

--- a/src/http/routes/bucket/createBucket.ts
+++ b/src/http/routes/bucket/createBucket.ts
@@ -9,6 +9,8 @@ const createBucketBodySchema = {
     name: { type: 'string', examples: ['avatars'] },
     id: { type: 'string', examples: ['avatars'] },
     public: { type: 'boolean', examples: [false] },
+    max_file_size_kb: { type: 'integer', minimum: 1 },
+    allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
   required: ['name'],
 } as const

--- a/src/http/routes/bucket/createBucket.ts
+++ b/src/http/routes/bucket/createBucket.ts
@@ -9,7 +9,7 @@ const createBucketBodySchema = {
     name: { type: 'string', examples: ['avatars'] },
     id: { type: 'string', examples: ['avatars'] },
     public: { type: 'boolean', examples: [false] },
-    max_file_size_kb: { type: 'integer', minimum: 1 },
+    file_size_limit: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
     allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
   required: ['name'],
@@ -29,6 +29,7 @@ interface createBucketRequestInterface extends AuthenticatedRequest {
 export default async function routes(fastify: FastifyInstance) {
   const summary = 'Create a bucket'
   const schema = createDefaultSchema(successResponseSchema, {
+    allowUnionTypes: true,
     body: createBucketBodySchema,
     summary,
     tags: ['bucket'],
@@ -46,7 +47,7 @@ export default async function routes(fastify: FastifyInstance) {
         public: isPublic,
         id,
         allowed_mime_types,
-        max_file_size_kb,
+        file_size_limit,
       } = request.body
 
       const bucket = await request.storage.createBucket({
@@ -54,8 +55,8 @@ export default async function routes(fastify: FastifyInstance) {
         name: bucketName,
         owner,
         public: isPublic ?? false,
-        max_file_size_kb,
-        allowed_mime_types,
+        fileSizeLimit: file_size_limit,
+        allowedMimeTypes: allowed_mime_types,
       })
 
       request.log.info({ results: bucket }, 'results')

--- a/src/http/routes/bucket/createBucket.ts
+++ b/src/http/routes/bucket/createBucket.ts
@@ -41,13 +41,21 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const owner = request.owner
 
-      const { name: bucketName, public: isPublic, id } = request.body
+      const {
+        name: bucketName,
+        public: isPublic,
+        id,
+        allowed_mime_types,
+        max_file_size_kb,
+      } = request.body
 
       const bucket = await request.storage.createBucket({
         id: id ?? bucketName,
         name: bucketName,
         owner,
         public: isPublic ?? false,
+        max_file_size_kb,
+        allowed_mime_types,
       })
 
       request.log.info({ results: bucket }, 'results')

--- a/src/http/routes/bucket/getBucket.ts
+++ b/src/http/routes/bucket/getBucket.ts
@@ -34,7 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       const results = await request.storage.findBucket(
         bucketId,
-        'id, name, owner, public, created_at, updated_at'
+        'id, name, owner, public, created_at, updated_at, max_file_size_kb, allowed_mime_types'
       )
 
       request.log.info({ results }, 'results')

--- a/src/http/routes/bucket/getBucket.ts
+++ b/src/http/routes/bucket/getBucket.ts
@@ -34,7 +34,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       const results = await request.storage.findBucket(
         bucketId,
-        'id, name, owner, public, created_at, updated_at, max_file_size_kb, allowed_mime_types'
+        'id, name, owner, public, created_at, updated_at, file_size_limit, allowed_mime_types'
       )
 
       request.log.info({ results }, 'results')

--- a/src/http/routes/bucket/updateBucket.ts
+++ b/src/http/routes/bucket/updateBucket.ts
@@ -7,8 +7,8 @@ const updateBucketBodySchema = {
   type: 'object',
   properties: {
     public: { type: 'boolean', examples: [false] },
-    maxFileSizeKb: { type: 'integer', minimum: 1, examples: [1000] },
-    allowedMimeTypes: { type: 'array', items: { type: 'string' } },
+    max_file_size_kb: { type: 'integer', minimum: 1 },
+    allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
 } as const
 const updateBucketParamsSchema = {
@@ -46,12 +46,12 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketId } = request.params
 
-      const { public: isPublic, maxFileSizeKb, allowedMimeTypes } = request.body
+      const { public: isPublic, max_file_size_kb, allowed_mime_types } = request.body
 
       await request.storage.updateBucket(bucketId, {
         public: isPublic,
-        max_file_size_kb: maxFileSizeKb,
-        allowed_mime_types: allowedMimeTypes,
+        max_file_size_kb: max_file_size_kb,
+        allowed_mime_types: allowed_mime_types,
       })
 
       return response.status(200).send(createResponse('Successfully updated'))

--- a/src/http/routes/bucket/updateBucket.ts
+++ b/src/http/routes/bucket/updateBucket.ts
@@ -7,6 +7,8 @@ const updateBucketBodySchema = {
   type: 'object',
   properties: {
     public: { type: 'boolean', examples: [false] },
+    maxFileSizeKb: { type: 'integer', minimum: 1, examples: [1000] },
+    allowedMimeTypes: { type: 'array', items: { type: 'string' } },
   },
 } as const
 const updateBucketParamsSchema = {
@@ -44,9 +46,13 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketId } = request.params
 
-      const { public: isPublic } = request.body
+      const { public: isPublic, maxFileSizeKb, allowedMimeTypes } = request.body
 
-      await request.storage.updateBucket(bucketId, isPublic)
+      await request.storage.updateBucket(bucketId, {
+        public: isPublic,
+        max_file_size_kb: maxFileSizeKb,
+        allowed_mime_types: allowedMimeTypes,
+      })
 
       return response.status(200).send(createResponse('Successfully updated'))
     }

--- a/src/http/routes/bucket/updateBucket.ts
+++ b/src/http/routes/bucket/updateBucket.ts
@@ -7,7 +7,7 @@ const updateBucketBodySchema = {
   type: 'object',
   properties: {
     public: { type: 'boolean', examples: [false] },
-    max_file_size_kb: { type: 'integer', minimum: 1 },
+    file_size_limit: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
     allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
 } as const
@@ -46,12 +46,12 @@ export default async function routes(fastify: FastifyInstance) {
     async (request, response) => {
       const { bucketId } = request.params
 
-      const { public: isPublic, max_file_size_kb, allowed_mime_types } = request.body
+      const { public: isPublic, file_size_limit, allowed_mime_types } = request.body
 
       await request.storage.updateBucket(bucketId, {
         public: isPublic,
-        max_file_size_kb: max_file_size_kb,
-        allowed_mime_types: allowed_mime_types,
+        fileSizeLimit: file_size_limit,
+        allowedMimeTypes: allowed_mime_types?.filter((mime) => mime),
       })
 
       return response.status(200).send(createResponse('Successfully updated'))

--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -16,6 +16,8 @@ export const logger = pino({
     res(reply) {
       return {
         statusCode: reply.statusCode,
+        contentLength: reply.headers['content-length'],
+        contentType: reply.headers['content-type'],
       }
     },
     req(request) {

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -53,7 +53,12 @@ export class Database {
     return new Database(this.options.superAdmin, this.options)
   }
 
-  async createBucket(data: Pick<Bucket, 'id' | 'name' | 'public' | 'owner'>) {
+  async createBucket(
+    data: Pick<
+      Bucket,
+      'id' | 'name' | 'public' | 'owner' | 'max_file_size_kb' | 'allowed_mime_types'
+    >
+  ) {
     const {
       data: results,
       error,
@@ -67,6 +72,8 @@ export class Database {
             name: data.name,
             owner: data.owner,
             public: data.public,
+            allowed_mime_types: data.allowed_mime_types,
+            max_file_size_kb: data.max_file_size_kb,
           },
         ],
         {
@@ -157,11 +164,16 @@ export class Database {
     return data as Bucket[]
   }
 
-  async updateBucket(bucketId: string, isPublic?: boolean) {
+  async updateBucket(
+    bucketId: string,
+    fields: Pick<Bucket, 'public' | 'max_file_size_kb' | 'allowed_mime_types'>
+  ) {
     const { error, status, data } = await this.postgrest
       .from<Bucket>('buckets')
       .update({
-        public: isPublic,
+        public: fields.public,
+        max_file_size_kb: fields.max_file_size_kb,
+        allowed_mime_types: fields.allowed_mime_types,
       })
       .match({ id: bucketId })
       .single()

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -56,7 +56,7 @@ export class Database {
   async createBucket(
     data: Pick<
       Bucket,
-      'id' | 'name' | 'public' | 'owner' | 'max_file_size_kb' | 'allowed_mime_types'
+      'id' | 'name' | 'public' | 'owner' | 'file_size_limit' | 'allowed_mime_types'
     >
   ) {
     const {
@@ -73,7 +73,7 @@ export class Database {
             owner: data.owner,
             public: data.public,
             allowed_mime_types: data.allowed_mime_types,
-            max_file_size_kb: data.max_file_size_kb,
+            file_size_limit: data.file_size_limit,
           },
         ],
         {
@@ -166,14 +166,14 @@ export class Database {
 
   async updateBucket(
     bucketId: string,
-    fields: Pick<Bucket, 'public' | 'max_file_size_kb' | 'allowed_mime_types'>
+    fields: Pick<Bucket, 'public' | 'file_size_limit' | 'allowed_mime_types'>
   ) {
     const { error, status, data } = await this.postgrest
       .from<Bucket>('buckets')
       .update({
         public: fields.public,
-        max_file_size_kb: fields.max_file_size_kb,
-        allowed_mime_types: fields.allowed_mime_types,
+        file_size_limit: fields.file_size_limit,
+        allowed_mime_types: fields.allowed_mime_types === null ? [] : fields.allowed_mime_types,
       })
       .match({ id: bucketId })
       .single()

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -76,3 +76,36 @@ export function mustBeValidBucketName(key: string, message: string) {
     throw new StorageBackendError('Invalid Input', 400, message)
   }
 }
+
+export function parseFileSizeToBytes(valueWithUnit: string) {
+  const valuesRegex = /(^[0-9]+(?:\.[0-9]+)?)(gb|mb|kb|b)$/i
+
+  if (!valuesRegex.test(valueWithUnit)) {
+    throw new StorageBackendError(
+      'file_size_limit',
+      422,
+      'the requested file_size_limit uses an invalid format, use 20GB / 20MB / 30KB / 3B'
+    )
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const [, valueS, unit] = valueWithUnit.match(valuesRegex)!
+  const value = +parseFloat(valueS).toPrecision(3)
+
+  switch (unit.toUpperCase()) {
+    case 'GB':
+      return value * 1e9
+    case 'MB':
+      return value * 1e6
+    case 'KB':
+      return value * 1000
+    case 'B':
+      return value
+    default:
+      throw new StorageBackendError(
+        'file_size_limit',
+        422,
+        'the requested file_size_limit unit is not supported, use GB/MB/KB/B'
+      )
+  }
+}

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -42,7 +42,7 @@ export class ObjectStorage {
   async uploadNewObject(request: FastifyRequest, options: UploadObjectOptions) {
     const bucket = await this.db
       .asSuperUser()
-      .findBucketById(this.bucketId, 'id, max_file_size_kb, allowed_mime_types')
+      .findBucketById(this.bucketId, 'id, file_size_limit, allowed_mime_types')
 
     await this.createObject(
       {
@@ -59,7 +59,7 @@ export class ObjectStorage {
       const uploader = new Uploader(this.backend)
       const objectMetadata = await uploader.upload(request, {
         key: s3Key,
-        maxFileSizeKb: bucket.max_file_size_kb,
+        fileSizeLimit: bucket.file_size_limit,
         allowedMimeTypes: bucket.allowed_mime_types,
       })
 
@@ -94,7 +94,7 @@ export class ObjectStorage {
   ) {
     const bucket = await this.db
       .asSuperUser()
-      .findBucketById(this.bucketId, 'id, max_file_size_kb, allowed_mime_types')
+      .findBucketById(this.bucketId, 'id, file_size_limit, allowed_mime_types')
 
     await this.updateObjectOwner(options.objectName, options.owner)
 
@@ -105,7 +105,7 @@ export class ObjectStorage {
       const uploader = new Uploader(this.backend)
       const objectMetadata = await uploader.upload(request, {
         key: s3Key,
-        maxFileSizeKb: bucket.max_file_size_kb,
+        fileSizeLimit: bucket.file_size_limit,
         allowedMimeTypes: bucket.allowed_mime_types,
       })
 

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -40,6 +40,10 @@ export class ObjectStorage {
    * @param options
    */
   async uploadNewObject(request: FastifyRequest, options: UploadObjectOptions) {
+    const bucket = await this.db
+      .asSuperUser()
+      .findBucketById(this.bucketId, 'id, max_file_size_kb, allowed_mime_types')
+
     await this.createObject(
       {
         name: options.objectName,
@@ -55,6 +59,8 @@ export class ObjectStorage {
       const uploader = new Uploader(this.backend)
       const objectMetadata = await uploader.upload(request, {
         key: s3Key,
+        maxFileSizeKb: bucket.max_file_size_kb,
+        allowedMimeTypes: bucket.allowed_mime_types,
       })
 
       await this.db
@@ -86,6 +92,10 @@ export class ObjectStorage {
     request: FastifyRequest,
     options: Omit<UploadObjectOptions, 'isUpsert'>
   ) {
+    const bucket = await this.db
+      .asSuperUser()
+      .findBucketById(this.bucketId, 'id, max_file_size_kb, allowed_mime_types')
+
     await this.updateObjectOwner(options.objectName, options.owner)
 
     const path = `${this.bucketId}/${options.objectName}`
@@ -95,6 +105,8 @@ export class ObjectStorage {
       const uploader = new Uploader(this.backend)
       const objectMetadata = await uploader.upload(request, {
         key: s3Key,
+        maxFileSizeKb: bucket.max_file_size_kb,
+        allowedMimeTypes: bucket.allowed_mime_types,
       })
 
       await this.db

--- a/src/storage/schemas/bucket.ts
+++ b/src/storage/schemas/bucket.ts
@@ -8,6 +8,8 @@ export const bucketSchema = {
     name: { type: 'string' },
     owner: { type: 'string' },
     public: { type: 'boolean' },
+    max_file_size_kb: { type: 'integer' },
+    allowed_mime_types: { type: 'array', items: { type: 'string' } },
     created_at: { type: 'string' },
     updated_at: { type: 'string' },
   },

--- a/src/storage/schemas/bucket.ts
+++ b/src/storage/schemas/bucket.ts
@@ -9,7 +9,7 @@ export const bucketSchema = {
     owner: { type: 'string' },
     public: { type: 'boolean' },
     max_file_size_kb: { type: 'integer' },
-    allowed_mime_types: { type: 'array', items: { type: 'string' } },
+    allowed_mime_types: { type: ['array', 'null'], items: { type: 'string' } },
     created_at: { type: 'string' },
     updated_at: { type: 'string' },
   },

--- a/src/storage/schemas/bucket.ts
+++ b/src/storage/schemas/bucket.ts
@@ -8,7 +8,7 @@ export const bucketSchema = {
     name: { type: 'string' },
     owner: { type: 'string' },
     public: { type: 'boolean' },
-    max_file_size_kb: { type: 'integer' },
+    file_size_limit: { type: 'integer' },
     allowed_mime_types: { type: ['array', 'null'], items: { type: 'string' } },
     created_at: { type: 'string' },
     updated_at: { type: 'string' },

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -183,7 +183,7 @@ export class Storage {
 
   protected async validateMaxSizeLimit(maxFileLimit: number) {
     const globalMaxLimit = await getFileSizeLimit(this.db.tenantId)
-    const globalMaxLimitKb = globalMaxLimit * 1000
+    const globalMaxLimitKb = globalMaxLimit / 1000
 
     if (maxFileLimit > globalMaxLimitKb) {
       throw new StorageBackendError(

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -6,8 +6,8 @@ import { StorageBackendError } from './errors'
 
 interface UploaderOptions {
   key: string
-  maxFileSizeKb?: number
-  allowedMimeTypes?: string[]
+  fileSizeLimit?: number
+  allowedMimeTypes?: string[] | null
 }
 
 const { globalS3Bucket } = getConfig()
@@ -55,14 +55,14 @@ export class Uploader {
 
   protected async incomingFileInfo(
     request: FastifyRequest,
-    options?: Pick<UploaderOptions, 'maxFileSizeKb'>
+    options?: Pick<UploaderOptions, 'fileSizeLimit'>
   ) {
     const contentType = request.headers['content-type']
     let fileSizeLimit = await getFileSizeLimit(request.tenantId)
 
-    if (options?.maxFileSizeKb) {
-      if (options.maxFileSizeKb * 1000 <= fileSizeLimit) {
-        fileSizeLimit = options.maxFileSizeKb * 1000
+    if (options?.fileSizeLimit) {
+      if (options.fileSizeLimit <= fileSizeLimit) {
+        fileSizeLimit = options.fileSizeLimit
       }
     }
 

--- a/src/test/bucket.test.ts
+++ b/src/test/bucket.test.ts
@@ -97,7 +97,7 @@ describe('testing GET all buckets', () => {
     })
     expect(response.statusCode).toBe(200)
     const responseJSON = JSON.parse(response.body)
-    expect(responseJSON.length).toBe(7)
+    expect(responseJSON.length).toBe(10)
   })
 
   test('checking RLS: anon user is not able to get all buckets', async () => {

--- a/src/test/db/04-dummy-data.sql.sample
+++ b/src/test/db/04-dummy-data.sql.sample
@@ -5,7 +5,7 @@ INSERT INTO "auth"."users" ("instance_id", "id", "aud", "role", "email", "encryp
 ('00000000-0000-0000-0000-000000000000', 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2', 'authenticated', 'authenticated', 'inian+admin@supabase.io', '', NULL, '2021-02-17 04:40:42.901743+00', '3EG99GjT_e3NC4eGEBXOjw', '2021-02-17 04:40:42.901743+00', '', NULL, '', '', NULL, NULL, '{"provider": "email"}', 'null', 'f', '2021-02-17 04:40:42.890632+00', '2021-02-17 04:40:42.890637+00');
 
 -- insert buckets
-INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public", "max_file_size_kb", "allowed_mime_types") VALUES
+INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public", "file_size_limit", "allowed_mime_types") VALUES
 ('bucket2', 'bucket2', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false, NULL, NULL),
 ('bucket3', 'bucket3', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false, NULL, NULL),
 ('bucket4', 'bucket4', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-25 09:23:01.58385+00', '2021-02-25 09:23:01.58385+00', false, NULL, NULL),
@@ -14,7 +14,7 @@ INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_a
 ('public-bucket', 'public-bucket', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, NULL),
 ('public-bucket-2', 'public-bucket-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, NULL),
 ('public-limit-max-size', 'public-limit-max-size', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, 10, NULL),
-('public-limit-max-size-2', 'public-limit-max-size-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, 3746, NULL),
+('public-limit-max-size-2', 'public-limit-max-size-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, 29526, NULL),
 ('public-limit-mime-types', 'public-limit-mime-types', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, '{"image/jpeg"}');
 
 

--- a/src/test/db/04-dummy-data.sql.sample
+++ b/src/test/db/04-dummy-data.sql.sample
@@ -5,14 +5,17 @@ INSERT INTO "auth"."users" ("instance_id", "id", "aud", "role", "email", "encryp
 ('00000000-0000-0000-0000-000000000000', 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2', 'authenticated', 'authenticated', 'inian+admin@supabase.io', '', NULL, '2021-02-17 04:40:42.901743+00', '3EG99GjT_e3NC4eGEBXOjw', '2021-02-17 04:40:42.901743+00', '', NULL, '', '', NULL, NULL, '{"provider": "email"}', 'null', 'f', '2021-02-17 04:40:42.890632+00', '2021-02-17 04:40:42.890637+00');
 
 -- insert buckets
-INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public") VALUES
-('bucket2', 'bucket2', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false),
-('bucket3', 'bucket3', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false),
-('bucket4', 'bucket4', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-25 09:23:01.58385+00', '2021-02-25 09:23:01.58385+00', false),
-('bucket5', 'bucket5', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', false),
-('bucket6', 'bucket6', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', false),
-('public-bucket', 'public-bucket', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true),
-('public-bucket-2', 'public-bucket-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true);
+INSERT INTO "storage"."buckets" ("id", "name", "owner", "created_at", "updated_at", "public", "max_file_size_kb", "allowed_mime_types") VALUES
+('bucket2', 'bucket2', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false, NULL, NULL),
+('bucket3', 'bucket3', '4d56e902-f0a0-4662-8448-a4d9e643c142', '2021-02-17 04:43:32.770206+00', '2021-02-17 04:43:32.770206+00', false, NULL, NULL),
+('bucket4', 'bucket4', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-25 09:23:01.58385+00', '2021-02-25 09:23:01.58385+00', false, NULL, NULL),
+('bucket5', 'bucket5', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', false, NULL, NULL),
+('bucket6', 'bucket6', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', false, NULL, NULL),
+('public-bucket', 'public-bucket', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, NULL),
+('public-bucket-2', 'public-bucket-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, NULL),
+('public-limit-max-size', 'public-limit-max-size', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, 10, NULL),
+('public-limit-max-size-2', 'public-limit-max-size-2', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, 3746, NULL),
+('public-limit-mime-types', 'public-limit-mime-types', '317eadce-631a-4429-a0bb-f19a7a517b4a', '2021-02-27 03:04:25.6386+00', '2021-02-27 03:04:25.6386+00', true, NULL, '{"image/jpeg"}');
 
 
 -- insert objects


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

- Allow creating buckets specifying a `file size limit` and white-listing `mime-types` which will serve for validating the file during upload

- Allow to update these values via the bucket update endpoint 

- Validate max file size and mime type during upload