### PR TITLE
feat(object): Allow for presigning upload url

### DIFF
--- a/migrations/tenant/0014-add-can-insert-object-function.sql
+++ b/migrations/tenant/0014-add-can-insert-object-function.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION storage.can_insert_object(bucketid text, name text, owner uuid, metadata jsonb)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO "storage"."objects" ("bucket_id", "name", "owner", "metadata") VALUES (bucketid, name, owner, metadata);
+  -- hack to rollback the successful insert
+  RAISE sqlstate 'PT200' using
+  message = 'ROLLBACK',
+  detail = 'rollback successful insert';
+END
+$$;

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -14,6 +14,12 @@ export type SignedToken = {
   exp: number
 }
 
+export type SignedUploadToken = {
+  owner: string | undefined
+  url: string
+  exp: number
+}
+
 /**
  * Gets the JWT secret key from the env PGRST_JWT_SECRET when running in single-tenant
  * or querying the multi-tenant database by the given tenantId

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ type StorageConfigType = {
   rateLimiterRenderPathMaxReqSec: number
   rateLimiterRedisConnectTimeout: number
   rateLimiterRedisCommandTimeout: number
+  signedUploadUrlExpirationTime: number
 }
 
 function getOptionalConfigFromEnv(key: string): string | undefined {
@@ -164,6 +165,9 @@ export function getConfig(): StorageConfigType {
     rateLimiterRedisCommandTimeout: parseInt(
       getOptionalConfigFromEnv('RATE_LIMITER_REDIS_COMMAND_TIMEOUT') || '2',
       10
+    ),
+    signedUploadUrlExpirationTime: parseInt(
+      getOptionalConfigFromEnv('SIGNED_UPLOAD_URL_EXPIRATION_TIME') || '60'
     ),
   }
 }

--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -1,0 +1,68 @@
+import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
+import { createDefaultSchema } from '../../generic-routes'
+import { AuthenticatedRequest } from '../../request'
+
+const getSignedUploadURLParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+const getSignedUploadURLBodySchema = {
+  type: 'object',
+  properties: {
+    expiresIn: { type: 'integer', minimum: 1, examples: [60000] },
+  },
+  required: ['expiresIn'],
+} as const
+
+const successResponseSchema = {
+  type: 'object',
+  properties: {
+    signedUploadURL: {
+      type: 'string',
+      examples: [
+        '/object/sign/upload/avatars/folder/cat.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJhdmF0YXJzL2ZvbGRlci9jYXQucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.s7Gt8ME80iREVxPhH01ZNv8oUn4XtaWsmiQ5csiUHn4',
+      ],
+    },
+  },
+  required: ['signedUploadURL'],
+}
+interface getSignedURLRequestInterface extends AuthenticatedRequest {
+  Params: FromSchema<typeof getSignedUploadURLParamsSchema>
+  Body: FromSchema<typeof getSignedUploadURLBodySchema>
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Generate a presigned url to upload an object'
+
+  const schema = createDefaultSchema(successResponseSchema, {
+    body: getSignedUploadURLBodySchema,
+    params: getSignedUploadURLParamsSchema,
+    summary,
+    tags: ['object'],
+  })
+
+  fastify.post<getSignedURLRequestInterface>(
+    '/upload/sign/:bucketName/*',
+    {
+      schema,
+    },
+    async (request, response) => {
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+      const { expiresIn } = request.body
+
+      const urlPath = request.url.split('?').shift()
+
+      const signedUploadURL = await request.storage
+        .from(bucketName)
+        .signUploadObjectUrl(objectName, urlPath as string, expiresIn)
+
+      return response.status(200).send({ signedUploadURL })
+    }
+  )
+}

--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -22,14 +22,14 @@ const getSignedUploadURLBodySchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
-    signedUploadURL: {
+    url: {
       type: 'string',
       examples: [
         '/object/sign/upload/avatars/folder/cat.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJhdmF0YXJzL2ZvbGRlci9jYXQucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.s7Gt8ME80iREVxPhH01ZNv8oUn4XtaWsmiQ5csiUHn4',
       ],
     },
   },
-  required: ['signedUploadURL'],
+  required: ['url'],
 }
 interface getSignedURLRequestInterface extends AuthenticatedRequest {
   Params: FromSchema<typeof getSignedUploadURLParamsSchema>
@@ -63,7 +63,7 @@ export default async function routes(fastify: FastifyInstance) {
         .from(bucketName)
         .signUploadObjectUrl(objectName, urlPath as string, expiresIn, owner)
 
-      return response.status(200).send({ signedUploadURL })
+      return response.status(200).send({ url: signedUploadURL })
     }
   )
 }

--- a/src/http/routes/object/getSignedUploadURL.ts
+++ b/src/http/routes/object/getSignedUploadURL.ts
@@ -55,12 +55,13 @@ export default async function routes(fastify: FastifyInstance) {
       const { bucketName } = request.params
       const objectName = request.params['*']
       const { expiresIn } = request.body
+      const owner = request.owner
 
       const urlPath = request.url.split('?').shift()
 
       const signedUploadURL = await request.storage
         .from(bucketName)
-        .signUploadObjectUrl(objectName, urlPath as string, expiresIn)
+        .signUploadObjectUrl(objectName, urlPath as string, expiresIn, owner)
 
       return response.status(200).send({ signedUploadURL })
     }

--- a/src/http/routes/object/index.ts
+++ b/src/http/routes/object/index.ts
@@ -16,6 +16,8 @@ import {
   publicRoutes as getObjectInfoPublic,
   authenticatedRoutes as getObjectInfoAuth,
 } from './getObjectInfo'
+import getSignedUploadURL from './getSignedUploadURL'
+import uploadSignedObject from './uploadSignedObject'
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(async function authorizationContext(fastify) {
@@ -27,6 +29,7 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(deleteObject)
     fastify.register(deleteObjects)
     fastify.register(getObject)
+    fastify.register(getSignedUploadURL)
     fastify.register(getSignedURL)
     fastify.register(getSignedURLs)
     fastify.register(moveObject)
@@ -42,6 +45,7 @@ export default async function routes(fastify: FastifyInstance) {
     fastify.register(storage)
     fastify.register(getPublicObject)
     fastify.register(getSignedObject)
+    fastify.register(uploadSignedObject)
     fastify.register(getObjectInfoPublic)
   })
 }

--- a/src/http/routes/object/uploadSignedObject.ts
+++ b/src/http/routes/object/uploadSignedObject.ts
@@ -1,0 +1,101 @@
+import { FastifyInstance } from 'fastify'
+import { FromSchema } from 'json-schema-to-ts'
+import { getJwtSecret, getOwner, verifyJWT } from '../../../auth'
+import { StorageBackendError } from '../../../storage'
+
+const uploadSignedObjectParamsSchema = {
+  type: 'object',
+  properties: {
+    bucketName: { type: 'string', examples: ['avatars'] },
+    '*': { type: 'string', examples: ['folder/cat.png'] },
+  },
+  required: ['bucketName', '*'],
+} as const
+
+const uploadSignedObjectQSSchema = {
+  type: 'object',
+  properties: {
+    token: {
+      type: 'string',
+      examples: [
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJidWNrZXQyL3B1YmxpYy9zYWRjYXQtdXBsb2FkMjMucG5nIiwiaWF0IjoxNjE3NzI2MjczLCJleHAiOjE2MTc3MjcyNzN9.uBQcXzuvXxfw-9WgzWMBfE_nR3VOgpvfZe032sfLSSk',
+      ],
+    },
+  },
+  required: ['token'],
+} as const
+
+const successResponseSchema = {
+  type: 'object',
+  properties: {
+    Key: { type: 'string', examples: ['projectref/avatars/folder/cat.png'] },
+  },
+  required: ['Key'],
+}
+
+interface UploadSignedObjectRequestInterface {
+  Params: FromSchema<typeof uploadSignedObjectParamsSchema>
+  Querystring: FromSchema<typeof uploadSignedObjectQSSchema>
+  Headers: {
+    range?: string
+  }
+}
+
+export default async function routes(fastify: FastifyInstance) {
+  const summary = 'Uploads an object via a presigned URL'
+
+  fastify.addContentTypeParser(
+    ['application/json', 'text/plain'],
+    function (request, payload, done) {
+      done(null)
+    }
+  )
+
+  fastify.put<UploadSignedObjectRequestInterface>(
+    '/upload/sign/:bucketName/*',
+    {
+      // @todo add success response schema here
+      schema: {
+        params: uploadSignedObjectParamsSchema,
+        querystring: uploadSignedObjectQSSchema,
+        summary,
+        response: {
+          200: { description: 'Succesful response', ...successResponseSchema },
+          '4xx': { $ref: 'errorSchema#', description: 'Error response' },
+        },
+        tags: ['object'],
+      },
+    },
+    async (request, response) => {
+      // Validate sender
+      const { token } = request.query
+
+      const jwtSecret = await getJwtSecret(request.tenantId)
+      try {
+        await verifyJWT(token, jwtSecret)
+      } catch (e) {
+        const err = e as Error
+        throw new StorageBackendError('Invalid JWT', 400, err.message, err)
+      }
+
+      const contentType = request.headers['content-type']
+      request.log.info(`content-type is ${contentType}`)
+
+      const { bucketName } = request.params
+      const objectName = request.params['*']
+      const owner = await getOwner(token, jwtSecret)
+
+      const { objectMetadata, path } = await request.storage
+        .asSuperUser()
+        .from(bucketName)
+        .uploadNewObject(request, {
+          owner,
+          objectName: objectName,
+        })
+
+      return response.status(objectMetadata?.httpStatusCode ?? 200).send({
+        Key: path,
+      })
+    }
+  )
+}

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -399,4 +399,22 @@ export class Database {
 
     return data as Obj[]
   }
+
+  async canInsertObject(data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata'>) {
+    const { error, status } = await this.postgrest.rpc<void>('can_insert_object', {
+      bucketid: data.bucket_id,
+      name: data.name,
+      owner: data.owner ?? null,
+      metadata: data.metadata,
+    })
+
+    if (error) {
+      throw new DatabaseError('cannot insert object', status, error, {
+        bucketId: data.bucket_id,
+        name: data.name,
+      })
+    }
+
+    return true
+  }
 }

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1230,12 +1230,14 @@ describe('testing generating signed URL', () => {
 /**
  * POST /upload/sign/:bucketName/*
  */
-
 describe('testing generating signed URL for upload', () => {
   test('check if RLS policies are respected: authenticated user is able to sign upload URL for a resource', async () => {
+    const BUCKET_ID = 'bucket2'
+    const OBJECT_NAME = 'authenticated/cat1.jpg'
+
     const response = await app().inject({
       method: 'POST',
-      url: '/object/upload/sign/bucket2/cat.jpg',
+      url: `/object/upload/sign/${BUCKET_ID}/${OBJECT_NAME}`,
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
@@ -1246,6 +1248,54 @@ describe('testing generating signed URL for upload', () => {
     expect(response.statusCode).toBe(200)
     const result = JSON.parse(response.body)
     expect(result.signedUploadURL).toBeTruthy()
+    // Ensure that row does not exist in database.
+    const postgrest = getSuperuserPostgrestClient()
+    const objectResponse = await postgrest
+      .from<Obj>('objects')
+      .select()
+      .match({
+        name: OBJECT_NAME,
+        bucket_id: BUCKET_ID,
+      })
+      .maybeSingle()
+    expect(objectResponse.error).toBe(null)
+    expect(objectResponse.data).toBe(null)
+  })
+
+  test('check if RLS policies are respected: anon user is not able to sign upload URL for authenticated resource', async () => {
+    const BUCKET_ID = 'bucket2'
+    const OBJECT_NAME = 'authenticated/cat1.jpg'
+
+    const response = await app().inject({
+      method: 'POST',
+      url: `/object/upload/sign/${BUCKET_ID}/${OBJECT_NAME}`,
+      headers: {
+        authorization: `Bearer ${anonKey}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toBe(
+      JSON.stringify({
+        statusCode: '403',
+        error: '',
+        message: 'new row violates row-level security policy for table "objects"',
+      })
+    )
+    // Ensure that row does not exist in database.
+    const postgrest = getSuperuserPostgrestClient()
+    const objectResponse = await postgrest
+      .from<Obj>('objects')
+      .select()
+      .match({
+        name: OBJECT_NAME,
+        bucket_id: BUCKET_ID,
+      })
+      .maybeSingle()
+    expect(objectResponse.error).toBe(null)
+    expect(objectResponse.data).toBe(null)
   })
 
   test('user is not able to sign a upload url without Auth header', async () => {
@@ -1300,6 +1350,114 @@ describe('testing generating signed URL for upload', () => {
     })
     expect(response.statusCode).toBe(400)
     expect(JSON.parse(response.body).statusCode).toBe('409')
+  })
+})
+
+/**
+ * PUT /upload/sign/:bucketName/*
+ */
+describe('testing uploading with generated signed upload URL', () => {
+  test('upload object with a token', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const BUCKET_ID = 'bucket2'
+    const OBJECT_NAME = 'public/sadcat-upload1.png'
+    const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+
+    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, 100)
+    const response = await app().inject({
+      method: 'PUT',
+      url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(S3Backend.prototype.uploadObject).toHaveBeenCalled()
+
+    // check that row has neccessary data
+    const postgrest = getSuperuserPostgrestClient()
+    const objectResponse = await postgrest
+      .from<Obj>('objects')
+      .select()
+      .match({
+        name: OBJECT_NAME,
+        bucket_id: BUCKET_ID,
+      })
+      .maybeSingle()
+    expect(objectResponse.error).toBe(null)
+    expect(objectResponse.data?.owner).toBe(owner)
+
+    // remove row to not to break other tests
+    await postgrest
+      .from<Obj>('objects')
+      .delete()
+      .match({
+        name: OBJECT_NAME,
+        bucket_id: BUCKET_ID,
+      })
+      .maybeSingle()
+  })
+
+  test('upload object without a token', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const response = await app().inject({
+      method: 'PUT',
+      url: `/object/upload/sign/bucket2/public/sadcat-upload1.png`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('upload object with a malformed JWT', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const response = await app().inject({
+      method: 'PUT',
+      url: `/object/upload/sign/bucket2/public/sadcat-upload1.png?token=xxx`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
+  })
+
+  test('upload object with an expired JWT', async () => {
+    const form = new FormData()
+    form.append('file', fs.createReadStream(`./src/test/assets/sadcat.jpg`))
+    const headers = Object.assign({}, form.getHeaders(), {
+      'content-type': 'image/jpeg',
+    })
+
+    const BUCKET_ID = 'bucket2'
+    const OBJECT_NAME = 'public/sadcat-upload1.png'
+    const urlToSign = `${BUCKET_ID}/${OBJECT_NAME}`
+    const owner = '317eadce-631a-4429-a0bb-f19a7a517b4a'
+
+    const jwtToken = await signJWT({ owner, url: urlToSign }, jwtSecret, -1)
+    const response = await app().inject({
+      method: 'PUT',
+      url: `/object/upload/sign/${urlToSign}?token=${jwtToken}`,
+      headers,
+      payload: form,
+    })
+    expect(response.statusCode).toBe(400)
+    expect(S3Backend.prototype.uploadObject).not.toHaveBeenCalled()
   })
 })
 

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1241,9 +1241,6 @@ describe('testing generating signed URL for upload', () => {
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
-      payload: {
-        expiresIn: 1000,
-      },
     })
     expect(response.statusCode).toBe(200)
     const result = JSON.parse(response.body)
@@ -1272,9 +1269,6 @@ describe('testing generating signed URL for upload', () => {
       headers: {
         authorization: `Bearer ${anonKey}`,
       },
-      payload: {
-        expiresIn: 1000,
-      },
     })
     expect(response.statusCode).toBe(400)
     expect(response.body).toBe(
@@ -1302,9 +1296,6 @@ describe('testing generating signed URL for upload', () => {
     const response = await app().inject({
       method: 'POST',
       url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
-      payload: {
-        expiresIn: 1000,
-      },
     })
     expect(response.statusCode).toBe(400)
   })
@@ -1315,9 +1306,6 @@ describe('testing generating signed URL for upload', () => {
       url: '/object/upload/sign/notfound/authenticated/cat.jpg',
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
-      },
-      payload: {
-        expiresIn: 1000,
       },
     })
     expect(response.statusCode).toBe(400)
@@ -1330,9 +1318,6 @@ describe('testing generating signed URL for upload', () => {
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
       },
-      payload: {
-        expiresIn: 1000,
-      },
     })
     expect(response.statusCode).toBe(200)
   })
@@ -1343,9 +1328,6 @@ describe('testing generating signed URL for upload', () => {
       url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
       headers: {
         authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
-      },
-      payload: {
-        expiresIn: 1000,
       },
     })
     expect(response.statusCode).toBe(400)

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1247,7 +1247,7 @@ describe('testing generating signed URL for upload', () => {
     })
     expect(response.statusCode).toBe(200)
     const result = JSON.parse(response.body)
-    expect(result.signedUploadURL).toBeTruthy()
+    expect(result.url).toBeTruthy()
     // Ensure that row does not exist in database.
     const postgrest = getSuperuserPostgrestClient()
     const objectResponse = await postgrest

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -1145,6 +1145,82 @@ describe('testing generating signed URL', () => {
 })
 
 /**
+ * POST /upload/sign/:bucketName/*
+ */
+
+describe('testing generating signed URL for upload', () => {
+  test('check if RLS policies are respected: authenticated user is able to sign upload URL for a resource', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    const result = JSON.parse(response.body)
+    expect(result.signedUploadURL).toBeTruthy()
+  })
+
+  test('user is not able to sign a upload url without Auth header', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('return 400 when generating signed upload urls from a non existent bucket', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/notfound/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  test('signing upload url of a non existent key', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/notfound.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(200)
+  })
+
+  test('signing upload url of an existent key', async () => {
+    const response = await app().inject({
+      method: 'POST',
+      url: '/object/upload/sign/bucket2/authenticated/cat.jpg',
+      headers: {
+        authorization: `Bearer ${process.env.AUTHENTICATED_KEY}`,
+      },
+      payload: {
+        expiresIn: 1000,
+      },
+    })
+    expect(response.statusCode).toBe(400)
+    expect(JSON.parse(response.body).statusCode).toBe('409')
+  })
+})
+
+/**
  * POST /sign/:bucketName
  */
 describe('testing generating signed URLs', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces a new feature to sign an upload url, which allows for uploading straight to the bucket without credentials.

## What is the current behavior?

It's currently not possible to upload a file from the client side, without routing it through your own server, which is not the preferred way.

## What is the new behavior?

You can now presign a upload url with your service token, and give the url to any client which can then upload the file directly.

## Additional context

Closes https://github.com/supabase/storage-api/issues/81
This PR fixes things from https://github.com/supabase/storage-api/pull/244. Thanks to @MagnusHJensen for prior work!
