### PR TITLE
feat: return object id on object operations

### DIFF
--- a/src/http/routes/object/copyObject.ts
+++ b/src/http/routes/object/copyObject.ts
@@ -15,10 +15,12 @@ const copyRequestBodySchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    id: { type: 'string', examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'] },
     Key: { type: 'string', examples: ['folder/destination.png'] },
   },
-  required: ['Key'],
+  required: ['Key', 'id'],
 }
+
 interface copyRequestInterface extends AuthenticatedRequest {
   Body: FromSchema<typeof copyRequestBodySchema>
 }
@@ -52,6 +54,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       return response.status(result.httpStatusCode ?? 200).send({
         Key: `${bucketId}/${destinationKey}`,
+        id: result.destObject.id,
       })
     }
   )

--- a/src/http/routes/object/createObject.ts
+++ b/src/http/routes/object/createObject.ts
@@ -13,6 +13,10 @@ const createObjectParamsSchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    id: {
+      type: 'string',
+      examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'],
+    },
     Key: {
       type: 'string',
       examples: ['avatars/folder/cat.png'],
@@ -61,7 +65,7 @@ export default async function routes(fastify: FastifyInstance) {
       const isUpsert = request.headers['x-upsert'] === 'true'
       const owner = request.owner as string
 
-      const { objectMetadata, path } = await request.storage
+      const { objectMetadata, path, id } = await request.storage
         .from(bucketName)
         .uploadNewObject(request, {
           objectName,
@@ -71,6 +75,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       return response.status(objectMetadata?.httpStatusCode ?? 200).send({
         Key: path,
+        id,
       })
     }
   )

--- a/src/http/routes/object/updateObject.ts
+++ b/src/http/routes/object/updateObject.ts
@@ -13,6 +13,10 @@ const updateObjectParamsSchema = {
 const successResponseSchema = {
   type: 'object',
   properties: {
+    id: {
+      type: 'string',
+      examples: ['2eb16359-ecd4-4070-8eb1-8408baa42493'],
+    },
     Key: { type: 'string', examples: ['projectref/avatars/folder/cat.png'] },
   },
   required: ['Key'],
@@ -56,7 +60,7 @@ export default async function routes(fastify: FastifyInstance) {
       const objectName = request.params['*']
       const owner = request.owner as string
 
-      const { objectMetadata, path } = await request.storage
+      const { objectMetadata, path, id } = await request.storage
         .from(bucketName)
         .uploadOverridingObject(request, {
           owner,
@@ -65,6 +69,7 @@ export default async function routes(fastify: FastifyInstance) {
 
       return response.status(objectMetadata?.httpStatusCode ?? 200).send({
         Key: path,
+        id,
       })
     }
   )

--- a/src/storage/database.ts
+++ b/src/storage/database.ts
@@ -204,7 +204,6 @@ export class Database {
         ],
         {
           onConflict: 'name, bucket_id',
-          returning: 'minimal',
         }
       )
       .single()
@@ -220,21 +219,20 @@ export class Database {
   }
 
   async createObject(data: Pick<Obj, 'name' | 'owner' | 'bucket_id' | 'metadata'>) {
-    const { error, status } = await this.postgrest
+    const {
+      error,
+      status,
+      data: result,
+    } = await this.postgrest
       .from<Obj>('objects')
-      .insert(
-        [
-          {
-            name: data.name,
-            owner: data.owner,
-            bucket_id: data.bucket_id,
-            metadata: data.metadata,
-          },
-        ],
+      .insert([
         {
-          returning: 'minimal',
-        }
-      )
+          name: data.name,
+          owner: data.owner,
+          bucket_id: data.bucket_id,
+          metadata: data.metadata,
+        },
+      ])
       .single()
 
     if (error) {
@@ -244,7 +242,7 @@ export class Database {
       })
     }
 
-    return null
+    return result as Obj
   }
 
   async deleteObject(bucketId: string, objectName: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

currently is not possible to create relationships from the client side to an object because the id is never returned

## What is the new behavior?

object id is returned on the following operations:

- `createObject`
- `copyObject`
- `updateObject`

## Additional context

Reimplemented this PR. https://github.com/supabase/storage-api/pull/197


One remark, when testing this locally I had problems with RLS. I couldn't insert anything because it always failed with a RLS `new row violates row-level security policy for table "objects"`. 


What a problem is, is the RLS. Because by removing the `returning: 'minimal'`. You need the select permission to insert a file right now. 

I don't know if that's a problem?