### PR TITLE
fix: resize type on signed url

### DIFF
--- a/src/http/routes/bucket/createBucket.ts
+++ b/src/http/routes/bucket/createBucket.ts
@@ -9,7 +9,7 @@ const createBucketBodySchema = {
     name: { type: 'string', examples: ['avatars'] },
     id: { type: 'string', examples: ['avatars'] },
     public: { type: 'boolean', examples: [false] },
-    file_size_limit: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+    file_size_limit: { anyOf: [{ type: 'integer' }, { type: 'string' }] },
     allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
   required: ['name'],

--- a/src/http/routes/bucket/updateBucket.ts
+++ b/src/http/routes/bucket/updateBucket.ts
@@ -7,7 +7,7 @@ const updateBucketBodySchema = {
   type: 'object',
   properties: {
     public: { type: 'boolean', examples: [false] },
-    file_size_limit: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+    file_size_limit: { anyOf: [{ type: 'integer' }, { type: 'string' }] },
     allowed_mime_types: { type: 'array', items: { type: 'string' } },
   },
 } as const

--- a/src/http/routes/object/getSignedURL.ts
+++ b/src/http/routes/object/getSignedURL.ts
@@ -68,9 +68,10 @@ export default async function routes(fastify: FastifyInstance) {
 
       const transformationOptions = imageTransformationEnabled
         ? {
-            transformations: ImageRenderer.applyTransformation(request.body.transform || {}).join(
-              ','
-            ),
+            transformations: ImageRenderer.applyTransformation(
+              request.body.transform || {},
+              true
+            ).join(','),
             format: request.body.transform?.format || '',
           }
         : undefined

--- a/src/storage/renderer/image.ts
+++ b/src/storage/renderer/image.ts
@@ -84,6 +84,56 @@ export class ImageRenderer extends Renderer {
   }
 
   /**
+   * Applies whitelisted transformations with specific limits applied
+   * @param options
+   * @param keepOriginal
+   */
+  static applyTransformation(options: TransformOptions, keepOriginal?: boolean): string[] {
+    const segments = []
+
+    if (options.height) {
+      segments.push(`height:${clamp(options.height, LIMITS.height.min, LIMITS.height.max)}`)
+    }
+
+    if (options.width) {
+      segments.push(`width:${clamp(options.width, LIMITS.width.min, LIMITS.width.max)}`)
+    }
+
+    if (options.width || options.height) {
+      if (keepOriginal) {
+        segments.push(`resize:${options.resize}`)
+      } else {
+        segments.push(`resizing_type:${this.formatResizeType(options.resize)}`)
+      }
+    }
+
+    if (options.quality) {
+      segments.push(`quality:${options.quality}`)
+    }
+
+    if (options.format && options.format !== 'origin') {
+      segments.push(`format:${options.format}`)
+    }
+
+    return segments
+  }
+
+  protected static formatResizeType(resize: TransformOptions['resize']) {
+    const defaultResize = 'fill'
+
+    switch (resize) {
+      case 'cover':
+        return defaultResize
+      case 'contain':
+        return 'fit'
+      case 'fill':
+        return 'force'
+      default:
+        return defaultResize
+    }
+  }
+
+  /**
    * Get the base http client
    */
   getClient() {
@@ -185,51 +235,6 @@ export class ImageRenderer extends Renderer {
       }
 
       throw e
-    }
-  }
-
-  /**
-   * Applies whitelisted transformations with specific limits applied
-   * @param options
-   */
-  static applyTransformation(options: TransformOptions): string[] {
-    const segments = []
-
-    if (options.height) {
-      segments.push(`height:${clamp(options.height, LIMITS.height.min, LIMITS.height.max)}`)
-    }
-
-    if (options.width) {
-      segments.push(`width:${clamp(options.width, LIMITS.width.min, LIMITS.width.max)}`)
-    }
-
-    if (options.width || options.height) {
-      segments.push(`resizing_type:${this.formatResizeType(options.resize)}`)
-    }
-
-    if (options.quality) {
-      segments.push(`quality:${options.quality}`)
-    }
-
-    if (options.format && options.format !== 'origin') {
-      segments.push(`format:${options.format}`)
-    }
-
-    return segments
-  }
-
-  protected static formatResizeType(resize: TransformOptions['resize']) {
-    const defaultResize = 'fill'
-
-    switch (resize) {
-      case 'cover':
-        return defaultResize
-      case 'contain':
-        return 'fit'
-      case 'fill':
-        return 'force'
-      default:
-        return defaultResize
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

- Resize type is now respected on signed rendered urls
- Integer first in validation param validation
