### PR TITLE
fix: remove unused pm2 from global installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN npm ci
 RUN npm run build
 
 FROM node:18-alpine
-RUN npm install -g pm2
 WORKDIR /app
 COPY migrations migrations
 COPY ecosystem.config.js package.json ./


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes https://github.com/supabase/cli/issues/932
relates to https://github.com/supabase/cli/issues/268

## What is the current behavior?

pm2 is no longer used to start node process so it's safe to remove

## What is the new behavior?

fixes error when pulling storage images in [docker rootless mode](https://docs.docker.com/engine/security/rootless/), ie.
```bash
docker image pull supabase/storage-api:v0.34.0
```

pm2 depends on nssocket which owns files with an arbitrarily large uid/gid. That breaks on docker rootless mode: https://github.com/moby/moby/issues/43576

## Additional context

```bash
gitpod /workspace/cli (main) $ docker image pull supabase/storage-api:v0.34.0
v0.34.0: Pulling from supabase/storage-api
f56be85fc22e: Pull complete 
51fa4270e0cc: Pull complete 
a89e758f145e: Pull complete 
d3f921cbf16e: Pull complete 
45ce1000756e: Extracting [==================================================>]  12.64MB/12.64MB
548fb4829dc2: Download complete 
bc04dcf8a3a7: Download complete 
cfcfbb0a6e5d: Download complete 
fb5468acd59f: Download complete 
12d555444c5a: Download complete 
failed to register layer: ApplyLayer exit status 1 stdout:  stderr: failed to Lchown "/usr/local/lib/node_modules/pm2/node_modules/nssocket/.npmignore" for UID 1389985163, GID 386085923 (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid): lchown /usr/local/lib/node_modules/pm2/node_modules/nssocket/.npmignore: invalid argument
```
