### PR TITLE
fix: limit connection pool to 1 when using external pool

### DIFF
--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -60,9 +60,7 @@ export class TenantConnection {
       searchPath: ['public', 'storage'],
       pool: {
         min: 0,
-        max: isExternalPool
-          ? options.maxConnections * 3
-          : options.maxConnections || databaseMaxConnections,
+        max: isExternalPool ? 1 : options.maxConnections || databaseMaxConnections,
       },
       connection: connectionString,
       acquireConnectionTimeout: databaseConnectionTimeout,

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -36,28 +36,26 @@ export interface UploadObjectOptions {
 export class Uploader {
   constructor(private readonly backend: StorageBackendAdapter, private readonly db: Database) {}
 
-  canUpload(options: Pick<UploadObjectOptions, 'bucketId' | 'objectName' | 'isUpsert'>) {
-    return this.db.withTransaction(async (db) => {
-      const shouldCreateObject = !options.isUpsert
+  async canUpload(options: Pick<UploadObjectOptions, 'bucketId' | 'objectName' | 'isUpsert'>) {
+    const shouldCreateObject = !options.isUpsert
 
-      if (shouldCreateObject) {
-        await db.testPermission((db) => {
-          return db.createObject({
-            bucket_id: options.bucketId,
-            name: options.objectName,
-            version: '1',
-          })
+    if (shouldCreateObject) {
+      await this.db.testPermission((db) => {
+        return db.createObject({
+          bucket_id: options.bucketId,
+          name: options.objectName,
+          version: '1',
         })
-      } else {
-        await db.testPermission((db) => {
-          return db.upsertObject({
-            bucket_id: options.bucketId,
-            name: options.objectName,
-            version: '1',
-          })
+      })
+    } else {
+      await this.db.testPermission((db) => {
+        return db.upsertObject({
+          bucket_id: options.bucketId,
+          name: options.objectName,
+          version: '1',
         })
-      }
-    })
+      })
+    }
   }
 
   /**

--- a/src/test/db/docker-compose.yml
+++ b/src/test/db/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       POSTGRESQL_USERNAME: postgres
       POSTGRESQL_HOST: db
       POSTGRESQL_PASSWORD: postgres
+      PGBOUNCER_POOL_MODE: transaction
     depends_on:
       - db
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Limit knex connection pool to 1 when using an external pool