### PR TITLE
feat: drop owner constraint + search_path extensions

### DIFF
--- a/migrations/tenant/0016-drop-owner-foreign-key.sql
+++ b/migrations/tenant/0016-drop-owner-foreign-key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE storage.objects
+    DROP CONSTRAINT IF EXISTS objects_owner_fkey;

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -63,7 +63,7 @@ export class TenantConnection {
 
     knexPool = knex({
       client: 'pg',
-      searchPath: ['public', 'storage'],
+      searchPath: ['public', 'storage', 'extensions'],
       pool: {
         min: 0,
         max: isExternalPool ? 1 : options.maxConnections || databaseMaxConnections,


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

- Currently, the `owner` column has a foreign key constraint to auth.users table.
This limits the flexibility of using an external user_id

## What is the new behavior?

- Drop the foreign key on the owner column

- Include extensions in the search_path for storage
