### PR TITLE
feat: log tenant id admin routes

### DIFF
--- a/src/admin-app.ts
+++ b/src/admin-app.ts
@@ -4,6 +4,8 @@ import { Registry } from 'prom-client'
 
 const build = (opts: FastifyServerOptions = {}, appInstance?: FastifyInstance): FastifyInstance => {
   const app = fastify(opts)
+  app.register(plugins.adminTenantId)
+  app.register(plugins.logTenantId)
   app.register(plugins.logRequest({ excludeUrls: ['/status', '/metrics'] }))
   app.register(routes.tenant, { prefix: 'tenants' })
 

--- a/src/http/plugins/log-request.ts
+++ b/src/http/plugins/log-request.ts
@@ -26,8 +26,9 @@ export const logRequest = (options: RequestLoggerOptions) =>
       const cIP = req.ip
       const statusCode = reply.statusCode
       const error = (reply.raw as any).executionError || reply.executionError
+      const tenantId = req.tenantId
 
-      const buildLogMessage = `${rMeth} | ${statusCode} | ${cIP} | ${rId} | ${rUrl} | ${uAgent}`
+      const buildLogMessage = `${tenantId} | ${rMeth} | ${statusCode} | ${cIP} | ${rId} | ${rUrl} | ${uAgent}`
 
       req.log.info(
         {

--- a/src/http/plugins/tenant-id.ts
+++ b/src/http/plugins/tenant-id.ts
@@ -19,3 +19,13 @@ export const tenantId = fastifyPlugin(async (fastify) => {
     request.tenantId = result[1]
   })
 })
+
+export const adminTenantId = fastifyPlugin(async (fastify) => {
+  fastify.decorateRequest('tenantId', tenantId)
+  fastify.addHook('onRequest', async (request) => {
+    const tenantId = (request.params as Record<string, undefined | string>).tenantId
+    if (!tenantId) return
+
+    request.tenantId = tenantId
+  })
+})

--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -14,11 +14,9 @@ export const logger = pino({
   },
   serializers: {
     res(reply) {
-      // console.log(reply)
       return {
         statusCode: reply.statusCode,
-        contentLength: reply.headers['content-length'],
-        contentType: reply.headers['content-type'],
+        headers: whitelistHeaders(reply.getHeaders()),
       }
     },
     req(request) {
@@ -71,6 +69,7 @@ const whitelistHeaders = (headers: Record<string, unknown>) => {
     'x-client-info',
     'x-forwarded-user-agent',
     'x-client-trace-id',
+    'x-upsert',
   ]
   const allowlistedResponseHeaders = [
     'cf-cache-status',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

- Log tenant id on admin routes
- Log whitelisted response headers
- Add tenant id on the log message
- Whitelist `x-upsert` header