### PR TITLE
feat: deprecate owner column in favour of owner_id

### DIFF
--- a/migrations/tenant/0017-add_owner_id_column_deprecate_owner.sql
+++ b/migrations/tenant/0017-add_owner_id_column_deprecate_owner.sql
@@ -1,0 +1,8 @@
+alter table storage.objects add column if not exists owner_id text default null;
+alter table storage.buckets add column if not exists owner_id text default null;
+
+comment on column storage.objects.owner is 'Field is deprecated, use owner_id instead';
+comment on column storage.buckets.owner is 'Field is deprecated, use owner_id instead';
+
+ALTER TABLE storage.buckets
+    DROP CONSTRAINT IF EXISTS buckets_owner_fkey;

--- a/src/monitoring/logger.ts
+++ b/src/monitoring/logger.ts
@@ -63,6 +63,8 @@ const whitelistHeaders = (headers: Record<string, unknown>) => {
     'host',
     'user-agent',
     'x-forwarded-proto',
+    'x-forwarded-host',
+    'x-forwarded-port',
     'referer',
     'content-length',
     'x-real-ip',

--- a/src/storage/limits.ts
+++ b/src/storage/limits.ts
@@ -109,3 +109,7 @@ export function parseFileSizeToBytes(valueWithUnit: string) {
       )
   }
 }
+
+export function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+}

--- a/src/storage/object.ts
+++ b/src/storage/object.ts
@@ -269,6 +269,7 @@ export class ObjectStorage {
       await this.uploader.canUpload({
         bucketId: this.bucketId,
         objectName: destinationKey,
+        owner,
         isUpsert: false,
       })
 

--- a/src/storage/schemas/object.ts
+++ b/src/storage/schemas/object.ts
@@ -8,6 +8,7 @@ export const objectSchema = {
     name: { type: 'string' },
     bucket_id: { type: 'string' },
     owner: { type: 'string' },
+    owner_id: { type: 'string' },
     version: { type: 'string' },
     id: { anyOf: [{ type: 'string' }, { type: 'null' }] },
     updated_at: { anyOf: [{ type: 'string' }, { type: 'null' }] },

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -129,6 +129,7 @@ describe('Tus multipart', () => {
       },
       name: objectName,
       owner: null,
+      owner_id: null,
       path_tokens: [objectName],
       updated_at: expect.any(Date),
       version: expect.any(String),


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- Deprecate `owner` column in favor of `owner_id` 
- owner_id is now of type `text`
- Write to both columns if the owner is uuid, otherwise only on the `owner_id` column 
