### PR TITLE
pool settings improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.9.5",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.350.0",
-        "@aws-sdk/lib-storage": "^3.182.0",
-        "@aws-sdk/node-http-handler": "^3.178.0",
-        "@aws-sdk/s3-request-presigner": "^3.182.0",
+        "@aws-sdk/client-s3": "3.350.0",
+        "@aws-sdk/lib-storage": "3.350.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/s3-request-presigner": "3.350.0",
         "@fastify/multipart": "^7.6.0",
         "@fastify/rate-limit": "^7.6.0",
         "@fastify/swagger": "^8.3.1",
@@ -413,17 +413,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
@@ -433,21 +422,6 @@
         "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
         "@aws-sdk/util-config-provider": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -468,106 +442,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-      "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.347.0",
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
-      "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/signature-v4": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/signature-v4-crt": "^3.118.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/signature-v4-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -577,16 +451,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-arn-parser": {
@@ -604,39 +468,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
       "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -730,69 +561,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -804,115 +572,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
       "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -967,94 +630,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-middleware": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
       "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1148,18 +727,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -1169,16 +736,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/url-parser": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
@@ -1458,46 +1015,10 @@
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
       "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1599,6 +1120,8 @@
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
       "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1607,19 +1130,19 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.182.0.tgz",
-      "integrity": "sha512-12MleBxo9f74R1x4rvVYEkyJyUtp+YNbpCSR+8v7VuBJm0LVugCbKRasle+xmWsWI/Pd20OXalzManWZIWMQDA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.350.0.tgz",
+      "integrity": "sha512-D9QTOWhu2nboJPNFOe/dEx0P7y66a0JPH6QY/JUM0QEn1IqUBmmHkkqsTaYzmG/Qbe438ghUOwEd48QiACj3xw==",
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": "3.182.0",
-        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/smithy-client": "3.347.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "@aws-sdk/abort-controller": "^3.0.0",
@@ -1647,39 +1170,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.178.0.tgz",
-      "integrity": "sha512-HCHonBmv5SWZMZqVNtWr73d6moZfcqTI87Xmi0Ofpra8tmu99WQpYgXmVLqK13wlPP2MJErBLkcDt15dsS0pJw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "@aws-sdk/util-config-provider": "3.170.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
       "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
         "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
@@ -1699,21 +1195,40 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.182.0.tgz",
-      "integrity": "sha512-F51nTuxdZ0oTuqU2+Ca+l/Ysvn6ukLyujvHhyJfolquKX+ra/CBEC/Unhksl7ORolehm+iwbryyO7MHq7BWGkA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/url-parser": "3.178.0",
-        "@aws-sdk/util-config-provider": "3.170.0",
-        "@aws-sdk/util-middleware": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
@@ -1722,18 +1237,6 @@
       "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
         "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
@@ -1780,18 +1283,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -1809,18 +1300,6 @@
       "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
         "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
@@ -1898,18 +1377,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -1938,18 +1405,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -1970,21 +1425,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.178.0.tgz",
-      "integrity": "sha512-/4IMPfSCsHZ3nFPPOFdNh+KlKkQE7LhesaxHEZA8f4qn/AnzBJUQLQ7iN4uvE+mD/WjNDUhNXX3ZqDRVaI2a+w==",
-      "dependencies": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -2012,15 +1452,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
-      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
@@ -2044,18 +1495,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
       "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2148,14 +1587,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
-      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
@@ -2166,18 +1605,6 @@
         "@aws-sdk/protocol-http": "3.347.0",
         "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-endpoints": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2235,46 +1662,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
       "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2306,34 +1697,69 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
-      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "dependencies": {
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
-      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "dependencies": {
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-uri-escape": "3.170.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
       "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.178.0",
         "tslib": "^2.3.1"
@@ -2343,22 +1769,31 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.182.0.tgz",
-      "integrity": "sha512-//pDrBCSXqBSJ1Xi5GhAaeY5M1yHNTytNuTmBkKSSorAwZ7cbnSmVhegXQdVXvNIRBex+nqIvKzYR9Tgt1IxVA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.350.0.tgz",
+      "integrity": "sha512-jguuFmxGKOOnrek0V2WSNDyXmoWjj+sIeYA1icd3OLLD/7SDlw5eF4Hvx49LRC+JhIOQtytrf7y7ZQXvvI7LgA==",
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": "3.182.0",
-        "@aws-sdk/middleware-sdk-s3": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4-multi-region": "3.180.0",
-        "@aws-sdk/smithy-client": "3.180.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-create-request": "3.180.0",
-        "@aws-sdk/util-format-url": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4-multi-region": "3.347.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-format-url": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
@@ -2396,6 +1831,8 @@
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
       "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.170.0",
         "@aws-sdk/types": "3.178.0",
@@ -2429,18 +1866,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.180.0.tgz",
-      "integrity": "sha512-3IjwOy/x6UroV3TAbeCwpCRmt/8TW89JI1r8gtDbpQ42WiQ/1J+R5a78NP8bYa53kiDghW6pKlvLcbuoh3zWHQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
+      "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "@aws-sdk/signature-v4-crt": "^3.118.0"
@@ -2451,17 +1887,101 @@
         }
       }
     },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
-      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
@@ -2494,29 +2014,43 @@
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
       "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
-      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.170.0.tgz",
-      "integrity": "sha512-2ivABL9GNsucfMMkgGjVdFidbDogtSr4FBVW12D4ltijOL82CAynGrnxHAczRGnmi5/1/Ir4ipkr9pAdRMGiGw==",
+    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-base64": {
@@ -2571,31 +2105,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
-      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-create-request": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.180.0.tgz",
-      "integrity": "sha512-wBYsn+oCCNwJvltTp0hE6PzV+yZCV4orZJvpVm9AlpuXHL0NL9Xr8vMx1v9zTxG7v0aNIWIG5I/JZXwNDzkg3Q==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.178.0",
-        "@aws-sdk/smithy-client": "3.180.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
@@ -2674,22 +2183,35 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.178.0.tgz",
-      "integrity": "sha512-otKBGoj4QDNdXNDUV6nTCWbAlqmrjGb6YddbwkM5lZuisLf51HE7oQnEDX6k0SRvLTq3Xk+JE7pa2RlkMfV2gQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.347.0.tgz",
+      "integrity": "sha512-y9UUEmWu0IBoMZ25NVjCCOwvAEa+xJ54WfiCsgwKeFyTHWYY2wZqJfARJtme/ezqrRa8neOcBJSVxjfJJegW+w==",
       "dependencies": {
-        "@aws-sdk/querystring-builder": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
       "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2712,6 +2234,8 @@
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
       "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2795,6 +2319,8 @@
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
       "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -4307,11 +3833,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
       "dependencies": {
-        "@smithy/types": "^1.0.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4319,9 +3845,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -12224,14 +11750,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/middleware-bucket-endpoint": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.347.0.tgz",
@@ -12241,18 +11759,6 @@
             "@aws-sdk/types": "3.347.0",
             "@aws-sdk/util-arn-parser": "3.310.0",
             "@aws-sdk/util-config-provider": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-          "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/url-parser": "3.347.0",
-            "@aws-sdk/util-middleware": "3.347.0",
             "tslib": "^2.5.0"
           }
         },
@@ -12267,92 +11773,11 @@
             "tslib": "^2.5.0"
           }
         },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-          "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-          "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
-          "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
-          "requires": {
-            "@aws-sdk/eventstream-codec": "3.347.0",
-            "@aws-sdk/is-array-buffer": "3.310.0",
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/util-hex-encoding": "3.310.0",
-            "@aws-sdk/util-middleware": "3.347.0",
-            "@aws-sdk/util-uri-escape": "3.310.0",
-            "@aws-sdk/util-utf8": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/signature-v4-multi-region": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
-          "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.347.0",
-            "@aws-sdk/signature-v4": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-          "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
           "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-          "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
             "tslib": "^2.5.0"
           }
         },
@@ -12368,30 +11793,6 @@
           "version": "3.310.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
           "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -12438,76 +11839,10 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-          "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/url-parser": "3.347.0",
-            "@aws-sdk/util-middleware": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-          "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-          "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-          "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-          "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -12554,76 +11889,10 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-          "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/url-parser": "3.347.0",
-            "@aws-sdk/util-middleware": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-          "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-          "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-          "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-          "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -12674,76 +11943,10 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
-          "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/url-parser": "3.347.0",
-            "@aws-sdk/util-middleware": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
-          "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
-          "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
-          "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-          "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
-          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -12819,30 +12022,11 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/querystring-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
-          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
           "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
-          "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.347.0",
-            "@aws-sdk/types": "3.347.0",
             "tslib": "^2.5.0"
           }
         }
@@ -13085,37 +12269,10 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-          "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/util-uri-escape": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -13206,21 +12363,23 @@
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
       "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.182.0.tgz",
-      "integrity": "sha512-12MleBxo9f74R1x4rvVYEkyJyUtp+YNbpCSR+8v7VuBJm0LVugCbKRasle+xmWsWI/Pd20OXalzManWZIWMQDA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.350.0.tgz",
+      "integrity": "sha512-D9QTOWhu2nboJPNFOe/dEx0P7y66a0JPH6QY/JUM0QEn1IqUBmmHkkqsTaYzmG/Qbe438ghUOwEd48QiACj3xw==",
       "requires": {
-        "@aws-sdk/middleware-endpoint": "3.182.0",
-        "@aws-sdk/smithy-client": "3.180.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/smithy-client": "3.347.0",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/md5-js": {
@@ -13243,18 +12402,6 @@
         }
       }
     },
-    "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.178.0.tgz",
-      "integrity": "sha512-HCHonBmv5SWZMZqVNtWr73d6moZfcqTI87Xmi0Ofpra8tmu99WQpYgXmVLqK13wlPP2MJErBLkcDt15dsS0pJw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "@aws-sdk/util-config-provider": "3.170.0",
-        "tslib": "^2.3.1"
-      }
-    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
@@ -13265,15 +12412,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13285,18 +12423,33 @@
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.182.0.tgz",
-      "integrity": "sha512-F51nTuxdZ0oTuqU2+Ca+l/Ysvn6ukLyujvHhyJfolquKX+ra/CBEC/Unhksl7ORolehm+iwbryyO7MHq7BWGkA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "requires": {
-        "@aws-sdk/middleware-serde": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/url-parser": "3.178.0",
-        "@aws-sdk/util-config-provider": "3.170.0",
-        "@aws-sdk/util-middleware": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
@@ -13309,15 +12462,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13350,15 +12494,6 @@
             "tslib": "^2.5.0"
           }
         },
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13379,15 +12514,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13446,15 +12572,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13479,15 +12596,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13504,18 +12612,6 @@
             "tslib": "^2.5.0"
           }
         }
-      }
-    },
-    "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.178.0.tgz",
-      "integrity": "sha512-/4IMPfSCsHZ3nFPPOFdNh+KlKkQE7LhesaxHEZA8f4qn/AnzBJUQLQ7iN4uvE+mD/WjNDUhNXX3ZqDRVaI2a+w==",
-      "requires": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -13539,12 +12635,22 @@
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.178.0.tgz",
-      "integrity": "sha512-TERiu/B4hYi5Jd4iQN9ECTWbt2IZweAgFB010MboM4CAPm6EcszEc/uCB4faLZNdJaksk1BhAR7koURcda8Sew==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "requires": {
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-signing": {
@@ -13565,15 +12671,6 @@
           "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
           "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
           "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
             "tslib": "^2.5.0"
           }
         },
@@ -13646,11 +12743,11 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.178.0.tgz",
-      "integrity": "sha512-ELYM5Imhlcz2zT1Z4OjVZwO564KvI4L9dMBxuUgO0fwommzjWqxR03yaRGhpGwpCP64d0Op5Koc/RKq5V92Wbw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
@@ -13664,15 +12761,6 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
@@ -13716,37 +12804,10 @@
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
-          "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.347.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
-          "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
-          "requires": {
-            "@aws-sdk/types": "3.347.0",
-            "@aws-sdk/util-uri-escape": "3.310.0",
-            "tslib": "^2.5.0"
-          }
-        },
         "@aws-sdk/types": {
           "version": "3.347.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
           "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.310.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
           "requires": {
             "tslib": "^2.5.0"
           }
@@ -13773,47 +12834,85 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.178.0.tgz",
-      "integrity": "sha512-GsnANW60mVYMlE16UGNSOwYZ6TbkoODvmDQi95SEPjM7asf4vihEyDvhxiGS/JvC18UyxRVWT89l/V3hR/SF7w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "requires": {
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.178.0.tgz",
-      "integrity": "sha512-vJXlExSshlHtGVvan/U6JihWvzf8t9QwH5I4F6HUY+exxMy5vFDYCnNqGAzbJwq7w/HME1gQWLoXq2k0uODz7g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "requires": {
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-uri-escape": "3.170.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/querystring-parser": {
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.178.0.tgz",
       "integrity": "sha512-dp3pLnsOvAcIF7Yn2PY5CIVWX7GvC33nSlWDYeLeCMapccwTbe6zBqreWbScmIGJra4QJTdjccpwo2Yxwhr5QQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.178.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.182.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.182.0.tgz",
-      "integrity": "sha512-//pDrBCSXqBSJ1Xi5GhAaeY5M1yHNTytNuTmBkKSSorAwZ7cbnSmVhegXQdVXvNIRBex+nqIvKzYR9Tgt1IxVA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.350.0.tgz",
+      "integrity": "sha512-jguuFmxGKOOnrek0V2WSNDyXmoWjj+sIeYA1icd3OLLD/7SDlw5eF4Hvx49LRC+JhIOQtytrf7y7ZQXvvI7LgA==",
       "requires": {
-        "@aws-sdk/middleware-endpoint": "3.182.0",
-        "@aws-sdk/middleware-sdk-s3": "3.178.0",
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4-multi-region": "3.180.0",
-        "@aws-sdk/smithy-client": "3.180.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-create-request": "3.180.0",
-        "@aws-sdk/util-format-url": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4-multi-region": "3.347.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-format-url": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/service-error-classification": {
@@ -13844,6 +12943,8 @@
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.178.0.tgz",
       "integrity": "sha512-8oOx6o0uOqlCDPM0dszfR1WHqd0E1VuFqez8iNItp0DhmhaCuanEwKYYA6HOkVu/MA6CsG6zDIJaFr5ODU2NvQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.170.0",
         "@aws-sdk/types": "3.178.0",
@@ -13871,25 +12972,91 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.180.0.tgz",
-      "integrity": "sha512-3IjwOy/x6UroV3TAbeCwpCRmt/8TW89JI1r8gtDbpQ42WiQ/1J+R5a78NP8bYa53kiDghW6pKlvLcbuoh3zWHQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.347.0.tgz",
+      "integrity": "sha512-838h7pbRCVYWlTl8W+r5+Z5ld7uoBObgAn7/RB1MQ4JjlkfLdN7emiITG6ueVL+7gWZNZc/4dXR/FJSzCgrkxQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.178.0",
-        "@aws-sdk/signature-v4": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "@aws-sdk/util-arn-parser": "3.170.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+          "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+          "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
+          "requires": {
+            "@aws-sdk/eventstream-codec": "3.347.0",
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.347.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.347.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+          "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+          "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.310.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+          "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.180.0.tgz",
-      "integrity": "sha512-1vWafiUdn6RvOsD4CyNjMeDtDujuPi4Iq4Db6HrFmVPpJAutOLlCg52Dt7k96KCcIKgxVAs6Br0Waef+pcoGNA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/token-providers": {
@@ -13917,24 +13084,37 @@
     "@aws-sdk/types": {
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.178.0.tgz",
-      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ=="
+      "integrity": "sha512-CrHxHzXSEr/Z3NLFvJgSGHGcD9tYUZ0Rhp8tFCSpD3TpBo3/Y7RIvqaEPvECsL52UEloeBhQf65AO8590YkVmQ==",
+      "optional": true,
+      "peer": true
     },
     "@aws-sdk/url-parser": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.178.0.tgz",
-      "integrity": "sha512-+Ch29d+IZG6zD1gNDVgFC00huY8ytrPdijAuNJ4DtPBTGP4zbrImw3js0GfvfBjLrQYBnclcAvSx4J1Q/8tqBQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-arn-parser": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.170.0.tgz",
-      "integrity": "sha512-2ivABL9GNsucfMMkgGjVdFidbDogtSr4FBVW12D4ltijOL82CAynGrnxHAczRGnmi5/1/Ir4ipkr9pAdRMGiGw==",
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-parser": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+          "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+          "requires": {
+            "@aws-sdk/types": "3.347.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-base64": {
@@ -13979,25 +13159,6 @@
             "tslib": "^2.5.0"
           }
         }
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz",
-      "integrity": "sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-create-request": {
-      "version": "3.180.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.180.0.tgz",
-      "integrity": "sha512-wBYsn+oCCNwJvltTp0hE6PzV+yZCV4orZJvpVm9AlpuXHL0NL9Xr8vMx1v9zTxG7v0aNIWIG5I/JZXwNDzkg3Q==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.178.0",
-        "@aws-sdk/smithy-client": "3.180.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
@@ -14064,19 +13225,31 @@
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.178.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.178.0.tgz",
-      "integrity": "sha512-otKBGoj4QDNdXNDUV6nTCWbAlqmrjGb6YddbwkM5lZuisLf51HE7oQnEDX6k0SRvLTq3Xk+JE7pa2RlkMfV2gQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.347.0.tgz",
+      "integrity": "sha512-y9UUEmWu0IBoMZ25NVjCCOwvAEa+xJ54WfiCsgwKeFyTHWYY2wZqJfARJtme/ezqrRa8neOcBJSVxjfJJegW+w==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.178.0",
-        "@aws-sdk/types": "3.178.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.347.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+          "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz",
       "integrity": "sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -14093,6 +13266,8 @@
       "version": "3.178.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.178.0.tgz",
       "integrity": "sha512-93WgrJKuwtv3f2r1Q04emzjMiwpYR5hysOHKMkrGOvAVZdDqe1UTjmtuxQadVi3DBr1KOT/d5uP9MjV8LqaUUA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -14162,6 +13337,8 @@
       "version": "3.170.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz",
       "integrity": "sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -15376,18 +14553,18 @@
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
       "requires": {
-        "@smithy/types": "^1.0.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
       "requires": {
         "tslib": "^2.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.350.0",
-    "@aws-sdk/lib-storage": "^3.182.0",
-    "@aws-sdk/node-http-handler": "^3.178.0",
-    "@aws-sdk/s3-request-presigner": "^3.182.0",
+    "@aws-sdk/client-s3": "3.350.0",
+    "@aws-sdk/lib-storage": "3.350.0",
+    "@aws-sdk/node-http-handler": "3.350.0",
+    "@aws-sdk/s3-request-presigner": "3.350.0",
     "@fastify/multipart": "^7.6.0",
     "@fastify/rate-limit": "^7.6.0",
     "@fastify/swagger": "^8.3.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,7 +119,7 @@ export function getConfig(): StorageConfigType {
       10
     ),
     databaseConnectionTimeout: parseInt(
-      getOptionalConfigFromEnv('DATABASE_CONNECTION_TIMEOUT') || '30000',
+      getOptionalConfigFromEnv('DATABASE_CONNECTION_TIMEOUT') || '3000',
       10
     ),
     region: getConfigFromEnv('REGION'),

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -42,10 +42,7 @@ export class StorageKnexDB implements Database {
 
     while (retryLeft > 0) {
       try {
-        const tnx = await this.connection.transaction(
-          transactionOptions?.isolation as Knex.IsolationLevels,
-          this.options.tnx
-        )()
+        const tnx = await this.connection.transactionProvider(this.options.tnx)()
 
         try {
           await this.connection.setScope(tnx)
@@ -475,7 +472,7 @@ export class StorageKnexDB implements Database {
     const needsNewTransaction = !tnx || differentScopes
 
     if (!tnx || needsNewTransaction) {
-      tnx = await this.connection.transaction(isolation, this.options.tnx)()
+      tnx = await this.connection.transactionProvider(this.options.tnx)()
       tnx.on('query-error', (error: DatabaseError) => {
         throw DBError.fromDBError(error)
       })

--- a/src/test/object.test.ts
+++ b/src/test/object.test.ts
@@ -12,11 +12,13 @@ import { StorageBackendError } from '../storage'
 import { useMockObject, useMockQueue } from './common'
 import { getPostgresConnection } from '../database'
 import { getServiceKeyUser } from '../database/tenant'
+import { Knex } from 'knex'
 
 dotenv.config({ path: '.env.test' })
 
 const { anonKey, jwtSecret, serviceKey, tenantId } = getConfig()
 
+let tnx: Knex.Transaction | undefined
 async function getSuperuserPostgrestClient() {
   const superUser = await getServiceKeyUser(tenantId)
 
@@ -26,13 +28,19 @@ async function getSuperuserPostgrestClient() {
     tenantId,
     host: 'localhost',
   })
-  const tnx = await conn.pool
+  tnx = await conn.transaction()
 
   return tnx
 }
 
 useMockObject()
 useMockQueue()
+
+afterEach(async () => {
+  if (tnx) {
+    await tnx.commit()
+  }
+})
 
 /*
  * GET /object/:id

--- a/src/test/rls.test.ts
+++ b/src/test/rls.test.ts
@@ -132,7 +132,7 @@ describe('RLS policies', () => {
 
   afterAll(async () => {
     await db.destroy()
-    await (storage.db as StorageKnexDB).connection.pool.destroy()
+    await (storage.db as StorageKnexDB).connection.dispose()
   })
 
   testSpec.tests.forEach((_test, index) => {

--- a/src/test/webhooks.test.ts
+++ b/src/test/webhooks.test.ts
@@ -294,7 +294,7 @@ describe('Webhooks', () => {
 
 async function createObject(pg: TenantConnection, bucketId: string) {
   const objectName = Date.now()
-  const tnx = pg.pool
+  const tnx = await pg.transaction()
 
   const [data] = await tnx
     .from<Obj>('objects')
@@ -315,6 +315,8 @@ async function createObject(pg: TenantConnection, bucketId: string) {
       },
     ])
     .returning('*')
+
+  await tnx.commit()
 
   return data as Obj
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "target": "ES2020",
     "outDir": "dist",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the new behavior?

- Remove manual polling when not using external pool, rely on reapInterval
- Add search path within the transaction
- Remove `propagateCreateError` config it as knex recommends to keep it set to `true`
- Lowered default connection timeout to 3s
- Fix S3 dependencies resolutions from previous dep-bot
