### PR TITLE
fix: support enforcing SSL connection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 
 type StorageBackendType = 'file' | 's3'
+
 type StorageConfigType = {
   keepAliveTimeout: number
   headersTimeout: number
@@ -20,6 +21,7 @@ type StorageConfigType = {
   jwtAlgorithm: string
   multitenantDatabaseUrl?: string
   databaseURL: string
+  databaseSSLRootCert?: string
   databasePoolURL?: string
   databaseMaxConnections: number
   databaseFreePoolAfterInactivity: number
@@ -108,6 +110,7 @@ export function getConfig(): StorageConfigType {
     jwtSecret: getOptionalIfMultitenantConfigFromEnv('PGRST_JWT_SECRET') || '',
     jwtAlgorithm: getOptionalConfigFromEnv('PGRST_JWT_ALGORITHM') || 'HS256',
     multitenantDatabaseUrl: getOptionalConfigFromEnv('MULTITENANT_DATABASE_URL'),
+    databaseSSLRootCert: getOptionalConfigFromEnv('DATABASE_SSL_ROOT_CERT'),
     databaseURL: getOptionalIfMultitenantConfigFromEnv('DATABASE_URL') || '',
     databasePoolURL: getOptionalConfigFromEnv('DATABASE_POOL_URL') || '',
     databaseMaxConnections: parseInt(

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -26,6 +26,7 @@ export abstract class Queue {
     if (isMultitenant) {
       url = pgQueueConnectionURL ?? multitenantDatabaseUrl
     }
+
     Queue.pgBoss = new PgBoss({
       connectionString: url,
       max: 4,


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

By setting the env variable `DATABASE_SSL_ROOT_CERT` storage api will connect via SSL with `sslmode=verify-ca`
