### PR TITLE
fix: return path in the sign-urls endpoint

### DIFF
--- a/src/http/routes/object/getSignedURLs.ts
+++ b/src/http/routes/object/getSignedURLs.ts
@@ -32,7 +32,7 @@ const successResponseSchema = {
         error: ['string', 'null'],
         examples: ['Either the object does not exist or you do not have access to it'],
       },
-      version: {
+      path: {
         type: 'string',
         examples: ['folder/cat.png'],
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix,

## What is the current behavior?

the path was not returned in the signURLs endpoint

## What is the new behavior?

The path is now returned

closes https://github.com/supabase/storage-api/issues/353
