### PR TITLE
fix: allow updating the poolUrl to empty string

### DIFF
--- a/src/http/routes/tenant/index.ts
+++ b/src/http/routes/tenant/index.ts
@@ -186,7 +186,7 @@ export default async function routes(fastify: FastifyInstance) {
         .update({
           anon_key: anonKey !== undefined ? encrypt(anonKey) : undefined,
           database_url: databaseUrl !== undefined ? encrypt(databaseUrl) : undefined,
-          database_pool_url: databasePoolUrl ? encrypt(databasePoolUrl) : undefined,
+          database_pool_url: databasePoolUrl !== undefined ? encrypt(databasePoolUrl) : undefined,
           max_connections: maxConnections ? Number(maxConnections) : undefined,
           file_size_limit: fileSizeLimit,
           jwt_secret: jwtSecret !== undefined ? encrypt(jwtSecret) : undefined,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Database pool URL cannot be set to empty

## What is the new behavior?

allow setting the databasePoolUrl to empty string