### PR TITLE
Enforce ssl when setting env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "md5-file": "^5.0.0",
         "pg": "^8.10.0",
         "pg-boss": "^8.1.1",
+        "pg-connection-string": "^2.6.2",
         "pg-listen": "^1.7.0",
         "pino": "^8.2.0",
         "pino-logflare": "^0.3.12",
@@ -8416,6 +8417,11 @@
         }
       }
     },
+    "node_modules/knex/node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
     "node_modules/knex/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -9293,9 +9299,9 @@
       }
     },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
     },
     "node_modules/pg-format": {
       "version": "1.0.4",
@@ -18088,6 +18094,11 @@
         "tildify": "2.0.0"
       },
       "dependencies": {
+        "pg-connection-string": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -18798,9 +18809,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
     },
     "pg-format": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "md5-file": "^5.0.0",
     "pg": "^8.10.0",
     "pg-boss": "^8.1.1",
+    "pg-connection-string": "^2.6.2",
     "pg-listen": "^1.7.0",
     "pino": "^8.2.0",
     "pino-logflare": "^0.3.12",

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ type StorageConfigType = {
   jwtAlgorithm: string
   multitenantDatabaseUrl?: string
   databaseURL: string
+  databaseForceSSL: boolean
   databaseSSLRootCert?: string
   databasePoolURL?: string
   databaseMaxConnections: number
@@ -111,6 +112,7 @@ export function getConfig(): StorageConfigType {
     jwtAlgorithm: getOptionalConfigFromEnv('PGRST_JWT_ALGORITHM') || 'HS256',
     multitenantDatabaseUrl: getOptionalConfigFromEnv('MULTITENANT_DATABASE_URL'),
     databaseSSLRootCert: getOptionalConfigFromEnv('DATABASE_SSL_ROOT_CERT'),
+    databaseForceSSL: getOptionalConfigFromEnv('DATABASE_SSL_FORCE') === 'true',
     databaseURL: getOptionalIfMultitenantConfigFromEnv('DATABASE_URL') || '',
     databasePoolURL: getOptionalConfigFromEnv('DATABASE_POOL_URL') || '',
     databaseMaxConnections: parseInt(

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -1,6 +1,7 @@
 import { Client, ClientConfig } from 'pg'
 import { migrate } from 'postgres-migrations'
 import { getConfig } from '../config'
+import { formatConnectionString } from './connection'
 
 const { multitenantDatabaseUrl, databaseSSLRootCert } = getConfig()
 
@@ -10,11 +11,13 @@ const { multitenantDatabaseUrl, databaseSSLRootCert } = getConfig()
 export async function runMigrations(): Promise<void> {
   console.log('running migrations')
   let ssl: ClientConfig['ssl'] | undefined = undefined
+  let databaseUrl = process.env.DATABASE_URL
 
   if (databaseSSLRootCert) {
     ssl = { ca: databaseSSLRootCert }
+    databaseUrl = formatConnectionString(databaseUrl || '')
   }
-  await connectAndMigrate(process.env.DATABASE_URL, './migrations/tenant', ssl)
+  await connectAndMigrate(databaseUrl, './migrations/tenant', ssl)
   console.log('finished migrations')
 }
 
@@ -36,6 +39,7 @@ export async function runMigrationsOnTenant(databaseUrl: string): Promise<void> 
 
   if (databaseSSLRootCert) {
     ssl = { ca: databaseSSLRootCert }
+    databaseUrl = formatConnectionString(databaseUrl)
   }
   await connectAndMigrate(databaseUrl, './migrations/tenant', ssl)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

query string sslmode takes always precedence

## What is the new behavior?

when setting `DATABASE_SSL_FORCE` the sslmode query string is stripped from the connection string and forced to use verify-ca (default: false)
