### PR TITLE
fix: allow disabling specific events for tenants

### DIFF
--- a/migrations/multitenant/0006-add-option-to-disable-created-event.sql
+++ b/migrations/multitenant/0006-add-option-to-disable-created-event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS disable_events text[] DEFAULT NULL;

--- a/src/database/tenant.ts
+++ b/src/database/tenant.ts
@@ -15,6 +15,7 @@ interface TenantConfig {
   features: Features
   jwtSecret: string
   serviceKey: string
+  disableEvents?: string[]
   serviceKeyPayload: {
     role: string
   }
@@ -90,6 +91,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
     feature_image_transformation,
     database_pool_url,
     max_connections,
+    disable_events,
   } = tenant
 
   const serviceKey = decrypt(service_key)
@@ -111,6 +113,7 @@ export async function getTenantConfig(tenantId: string): Promise<TenantConfig> {
         enabled: feature_image_transformation,
       },
     },
+    disableEvents: disable_events,
   }
   await cacheTenantConfigAndRunMigrations(tenantId, config)
   return config


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the new behavior?

This PR allows us to selectively decide which events shouldn't be queued for specific tenants.

## Additional context

A useful scenario would be to prevent `ObjectCreated` events from being sent to the queue for tenants that uploads at a very fast rate.


