### PR TITLE
fix: handle database overload gracefully

### DIFF
--- a/src/http/error-handler.ts
+++ b/src/http/error-handler.ts
@@ -20,7 +20,12 @@ export const setErrorHandler = (app: FastifyInstance) => {
 
     if (isRenderableError(error)) {
       const renderableError = error.render()
-      return reply.status(renderableError.statusCode === '500' ? 500 : 400).send(renderableError)
+      const statusCode = error.userStatusCode
+        ? error.userStatusCode
+        : renderableError.error === '500'
+        ? 500
+        : 400
+      return reply.status(statusCode).send(renderableError)
     }
 
     // Fastify errors


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When trying to acquire a connection on a overloaded database results in a 500 error

## What is the new behavior?

This PR handle this error gracefully returning the following status codes:

- 544 
  - when a timeout occur while trying to acquire a connection
- 429 
  - When too many requests are sent concurrently and pgBouncer is unable to accept any more clients, resulting in max_client connection
  - When no more Postgres connections are allowed for these users
