### PR TITLE
fix: add version env to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN npm ci
 RUN npm run build
 
 FROM node:18-alpine
+ARG VERSION
+ENV VERSION=$VERSION
 WORKDIR /app
 COPY migrations migrations
 COPY ecosystem.config.js package.json ./


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

VERSION env is not passed into the container via build args

## What is the new behavior?
assign VERSION env from build-args VERSION

