### PR TITLE
fix: move database overload error handler

### DIFF
--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -178,21 +178,6 @@ export class TenantConnection {
         )
       }
 
-      if (
-        e instanceof DatabaseError &&
-        [
-          'remaining connection slots are reserved for non-replication superuser connections',
-          'no more connections allowed',
-        ].some((msg) => (e as DatabaseError).message.includes(msg))
-      ) {
-        throw StorageBackendError.withStatusCode(
-          'too_many_connections',
-          429,
-          'Too many connections issued to the database',
-          e
-        )
-      }
-
       throw e
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently the error handler for detecting too many connections is located at the connection level, however this issue can happen in more than one place

## What is the new behavior?

The error is now handled at the main error handler level
