### PR TITLE
fix: default bucketId during creation

### DIFF
--- a/src/http/routes/bucket/createBucket.ts
+++ b/src/http/routes/bucket/createBucket.ts
@@ -61,7 +61,7 @@ export default async function routes(fastify: FastifyInstance) {
       } = request.body
 
       await request.storage.createBucket({
-        id: id ?? bucketName,
+        id: id || bucketName,
         name: bucketName,
         owner,
         public: isPublic ?? false,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When explicitly passing null to the id field during bucket creation the id is not set

## What is the new behavior?

id defaults to the bucket name when not defined
