### PR TITLE
performance / fix remove listeners on query and connection

### DIFF
--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -88,7 +88,6 @@ export class TenantConnection {
     DbActivePool.inc({ tenant_id: options.tenantId, is_external: isExternalPool.toString() })
 
     knexPool.client.pool.on('createSuccess', () => {
-      console.log('successs')
       DbActiveConnection.inc({
         tenant_id: options.tenantId,
         is_external: isExternalPool.toString(),

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -88,6 +88,7 @@ export class TenantConnection {
     DbActivePool.inc({ tenant_id: options.tenantId, is_external: isExternalPool.toString() })
 
     knexPool.client.pool.on('createSuccess', () => {
+      console.log('successs')
       DbActiveConnection.inc({
         tenant_id: options.tenantId,
         is_external: isExternalPool.toString(),
@@ -127,7 +128,8 @@ export class TenantConnection {
 
   async dispose() {
     if (this.options.isExternalPool) {
-      return this.pool.destroy()
+      await this.pool.destroy()
+      this.pool.client.removeAllListeners()
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Listeners seems to be still registered even when the connection is closed

## What is the new behavior?

Remove all unnecessary listeners
