### PR TITLE
use a singleton http agent for queue events + Reduce metrics cardinality

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 
-type StorageBackendType = 'file' | 's3'
+export type StorageBackendType = 'file' | 's3'
 
 type StorageConfigType = {
   version: string
@@ -12,7 +12,7 @@ type StorageConfigType = {
   encryptionKey: string
   fileSizeLimit: number
   fileStoragePath?: string
-  globalS3Protocol?: 'http' | 'https' | string
+  globalS3Protocol: 'http' | 'https'
   globalS3MaxSockets?: number
   globalS3Bucket: string
   globalS3Endpoint?: string
@@ -111,7 +111,9 @@ export function getConfig(): StorageConfigType {
     fileSizeLimit: Number(getConfigFromEnv('FILE_SIZE_LIMIT')),
     fileStoragePath: getOptionalConfigFromEnv('FILE_STORAGE_BACKEND_PATH'),
     globalS3MaxSockets: parseInt(getOptionalConfigFromEnv('GLOBAL_S3_MAX_SOCKETS') || '200', 10),
-    globalS3Protocol: getOptionalConfigFromEnv('GLOBAL_S3_PROTOCOL') || 'https',
+    globalS3Protocol: (getOptionalConfigFromEnv('GLOBAL_S3_PROTOCOL') || 'https') as
+      | 'http'
+      | 'https',
     globalS3Bucket: getConfigFromEnv('GLOBAL_S3_BUCKET'),
     globalS3Endpoint: getOptionalConfigFromEnv('GLOBAL_S3_ENDPOINT'),
     globalS3ForcePathStyle: getOptionalConfigFromEnv('GLOBAL_S3_FORCE_PATH_STYLE') === 'true',

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -85,24 +85,22 @@ export class TenantConnection {
       acquireConnectionTimeout: databaseConnectionTimeout,
     })
 
-    DbActivePool.inc({ tenant_id: options.tenantId, is_external: isExternalPool.toString() })
+    DbActivePool.inc({ is_external: isExternalPool.toString() })
 
     knexPool.client.pool.on('createSuccess', () => {
       DbActiveConnection.inc({
-        tenant_id: options.tenantId,
         is_external: isExternalPool.toString(),
       })
     })
 
     knexPool.client.pool.on('destroySuccess', () => {
       DbActiveConnection.dec({
-        tenant_id: options.tenantId,
         is_external: isExternalPool.toString(),
       })
     })
 
     knexPool.client.pool.on('poolDestroySuccess', () => {
-      DbActivePool.dec({ tenant_id: options.tenantId, is_external: isExternalPool.toString() })
+      DbActivePool.dec({ is_external: isExternalPool.toString() })
     })
 
     if (!isExternalPool) {

--- a/src/http/plugins/metrics.ts
+++ b/src/http/plugins/metrics.ts
@@ -1,5 +1,5 @@
 import fastifyPlugin from 'fastify-plugin'
-import { MetricsRegistrar, RequestErrors } from '../../monitoring/metrics'
+import { MetricsRegistrar } from '../../monitoring/metrics'
 import fastifyMetrics from 'fastify-metrics'
 import { getConfig } from '../../config'
 
@@ -33,26 +33,6 @@ export const metrics = ({ enabledEndpoint }: MetricsOptions) =>
         },
         registeredRoutesOnly: true,
         groupStatusCodes: true,
-        customLabels: {
-          tenant_id: (req) => {
-            return req.tenantId
-          },
-        },
       },
-    })
-
-    // Errors
-    fastify.addHook('onResponse', async (request, reply) => {
-      const error = (reply.raw as any).executionError || reply.executionError
-
-      if (error) {
-        RequestErrors.inc({
-          name: error.name || error.constructor.name,
-          tenant_id: request.tenantId,
-          path: request.routerPath,
-          method: request.routerMethod,
-          status: reply.statusCode,
-        })
-      }
     })
   })

--- a/src/http/plugins/storage.ts
+++ b/src/http/plugins/storage.ts
@@ -2,6 +2,7 @@ import fastifyPlugin from 'fastify-plugin'
 import { StorageBackendAdapter, createStorageBackend } from '../../storage/backend'
 import { Storage } from '../../storage'
 import { StorageKnexDB } from '../../storage/database'
+import { getConfig } from '../../config'
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -10,8 +11,10 @@ declare module 'fastify' {
   }
 }
 
+const { storageBackendType } = getConfig()
+
 export const storage = fastifyPlugin(async (fastify) => {
-  const storageBackend = createStorageBackend()
+  const storageBackend = createStorageBackend(storageBackendType)
 
   fastify.decorateRequest('storage', undefined)
   fastify.addHook('preHandler', async (request) => {

--- a/src/http/routes/tus/s3-store.ts
+++ b/src/http/routes/tus/s3-store.ts
@@ -53,11 +53,8 @@ export class S3Store extends BaseS3Store {
     const timer = S3UploadPart.startTimer()
 
     const result = await super.uploadPart(metadata, readStream, partNumber)
-    const resource = UploadId.fromString(metadata.file.id)
 
-    timer({
-      tenant_id: resource.tenant,
-    })
+    timer()
 
     return result
   }

--- a/src/monitoring/metrics.ts
+++ b/src/monitoring/metrics.ts
@@ -6,71 +6,65 @@ export const MetricsRegistrar = new Registry()
 export const FileUploadStarted = new client.Gauge({
   name: 'storage_api_upload_started',
   help: 'Upload started',
-  labelNames: ['tenant_id', 'region', 'is_multipart'],
+  labelNames: ['region', 'is_multipart'],
 })
 
 export const FileUploadedSuccess = new client.Gauge({
   name: 'storage_api_upload_success',
   help: 'Successful uploads',
-  labelNames: ['tenant_id', 'region', 'is_multipart'],
+  labelNames: ['region', 'is_multipart'],
 })
 
 export const DbQueryPerformance = new client.Histogram({
   name: 'storage_api_database_query_performance',
   help: 'Database query performance',
-  labelNames: ['tenant_id', 'region', 'name'],
-})
-
-export const RequestErrors = new client.Gauge({
-  name: 'storage_api_request_errors',
-  labelNames: ['tenant_id', 'region', 'method', 'path', 'status', 'name'],
-  help: 'Response Errors',
+  labelNames: ['region', 'name'],
 })
 
 export const QueueJobSchedulingTime = new client.Histogram({
   name: 'storage_api_queue_job_scheduled_time',
   help: 'Time taken to schedule a job in the queue',
-  labelNames: ['region', 'name', 'tenant_id'],
+  labelNames: ['region', 'name'],
 })
 
 export const QueueJobScheduled = new client.Gauge({
   name: 'storage_api_queue_job_scheduled',
   help: 'Current number of pending messages in the queue',
-  labelNames: ['region', 'name', 'tenant_id'],
+  labelNames: ['region', 'name'],
 })
 
 export const QueueJobCompleted = new client.Gauge({
   name: 'storage_api_queue_job_completed',
   help: 'Current number of processed messages in the queue',
-  labelNames: ['tenant_id', 'region', 'name'],
+  labelNames: ['region', 'name'],
 })
 
 export const QueueJobRetryFailed = new client.Gauge({
   name: 'storage_api_queue_job_retry_failed',
   help: 'Current number of failed attempts messages in the queue',
-  labelNames: ['tenant_id', 'region', 'name'],
+  labelNames: ['region', 'name'],
 })
 
 export const QueueJobError = new client.Gauge({
   name: 'storage_api_queue_job_error',
   help: 'Current number of errored messages in the queue',
-  labelNames: ['tenant_id', 'region', 'name'],
+  labelNames: ['region', 'name'],
 })
 
 export const S3UploadPart = new client.Histogram({
   name: 'storage_api_s3_upload_part',
   help: 'S3 upload part performance',
-  labelNames: ['tenant_id', 'region'],
+  labelNames: ['region'],
 })
 
 export const DbActivePool = new client.Gauge({
   name: 'storage_api_db_pool',
   help: 'Number of database pools created',
-  labelNames: ['tenant_id', 'region', 'is_external'],
+  labelNames: ['region', 'is_external'],
 })
 
 export const DbActiveConnection = new client.Gauge({
   name: 'storage_api_db_connections',
   help: 'Number of database connections',
-  labelNames: ['tenant_id', 'region', 'is_external'],
+  labelNames: ['region', 'is_external'],
 })

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -87,14 +87,12 @@ export abstract class Queue {
               const res = await event.handle(job)
 
               QueueJobCompleted.inc({
-                tenant_id: job.data.tenant.ref,
                 name: event.getQueueName(),
               })
 
               return res
             } catch (e) {
               QueueJobRetryFailed.inc({
-                tenant_id: job.data.tenant.ref,
                 name: event.getQueueName(),
               })
 
@@ -106,7 +104,6 @@ export abstract class Queue {
                   }
                   if (dbJob.retrycount === dbJob.retrylimit) {
                     QueueJobError.inc({
-                      tenant_id: job.data.tenant.ref,
                       name: event.getQueueName(),
                     })
                   }

--- a/src/storage/database/knex.ts
+++ b/src/storage/database/knex.ts
@@ -469,7 +469,6 @@ export class StorageKnexDB implements Database {
   ): Promise<Awaited<ReturnType<T>>> {
     const timer = DbQueryPerformance.startTimer({
       name: queryName,
-      tenant_id: this.options.tenantId,
     })
 
     let tnx = this.options.tnx

--- a/src/storage/uploader.ts
+++ b/src/storage/uploader.ts
@@ -70,7 +70,6 @@ export class Uploader {
   async prepareUpload(options: UploadObjectOptions) {
     await this.canUpload(options)
     FileUploadStarted.inc({
-      tenant_id: this.db.tenantId,
       is_multipart: Boolean(options.isMultipart).toString(),
     })
 
@@ -208,7 +207,6 @@ export class Uploader {
         await Promise.all(events)
 
         FileUploadedSuccess.inc({
-          tenant_id: db.tenantId,
           is_multipart: Boolean(isMultipart).toString(),
         })
 

--- a/src/test/rls.test.ts
+++ b/src/test/rls.test.ts
@@ -66,8 +66,9 @@ const testSpec = yaml.load(
   fs.readFileSync(path.resolve(__dirname, 'rls_tests.yaml'), 'utf8')
 ) as RlsTestSpec
 
-const { serviceKey, tenantId, jwtSecret, databaseURL, globalS3Bucket } = getConfig()
-const backend = createStorageBackend()
+const { serviceKey, tenantId, jwtSecret, databaseURL, globalS3Bucket, storageBackendType } =
+  getConfig()
+const backend = createStorageBackend(storageBackendType)
 const client = backend.client
 
 jest.setTimeout(10000)

--- a/src/test/tus.test.ts
+++ b/src/test/tus.test.ts
@@ -18,11 +18,11 @@ import { DetailedError } from 'tus-js-client'
 import { getServiceKeyUser } from '../database/tenant'
 import { checkBucketExists } from './common'
 
-const { serviceKey, tenantId, globalS3Bucket } = getConfig()
+const { serviceKey, tenantId, globalS3Bucket, storageBackendType } = getConfig()
 const oneChunkFile = fs.createReadStream(path.resolve(__dirname, 'assets', 'sadcat.jpg'))
 const localServerAddress = 'http://127.0.0.1:8999'
 
-const backend = createStorageBackend()
+const backend = createStorageBackend(storageBackendType)
 const client = backend.client
 
 describe('Tus multipart', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Everytime a queue message calls `createStorage` each storage client uses a different HTTP pool agent not taking advantage of keep-alive

- All metrics requires the `tenant_id` label, which creates high cardinality metrics

## What is the new behavior?

- All events are now sharing a single HTTP agent pool 
- reduce metrics cardinality by removing the `tenant_id` label
